### PR TITLE
correlateTBN.py bug fixes

### DIFF
--- a/lsl/writer/fitsidi.py
+++ b/lsl/writer/fitsidi.py
@@ -130,7 +130,7 @@ class WriterBase(object):
             self.source = source
             
         def __eq__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID == oID
@@ -138,7 +138,7 @@ class WriterBase(object):
                 raise TypeError("Unsupported type: '%s'" % type(other).__name__)
                 
         def __ne__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID != oID
@@ -146,7 +146,7 @@ class WriterBase(object):
                 raise TypeError("Unsupported type: '%s'" % type(other).__name__)
                 
         def __gt__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID > oID
@@ -154,7 +154,7 @@ class WriterBase(object):
                 raise TypeError("Unsupported type: '%s'" % type(other).__name__)
                 
         def __ge__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID >= oID
@@ -162,7 +162,7 @@ class WriterBase(object):
                 raise TypeError("Unsupported type: '%s'" % type(other).__name__)
                 
         def __lt__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID < oID
@@ -170,7 +170,7 @@ class WriterBase(object):
                 raise TypeError("Unsupported type: '%s'" % type(other).__name__)
                 
         def __le__(self, other):
-            if isinstance(other, _UVData):
+            if isinstance(other, self.__class__):
                 sID = (self.obsTime,  abs(self.pol))
                 oID = (other.obsTime, abs(other.pol)   )
                 return sID <= oID

--- a/scripts/correlateTBN.py
+++ b/scripts/correlateTBN.py
@@ -75,6 +75,7 @@ def process_chunk(idf, site, good, filename, int_time=5.0, LFFT=64, overlap=1, p
     for s in range(chunk_size):
         try:
             readT, t, data = idf.read(int_time)
+            t=t.unix
         except Exception as e:
             print("Error: %s" % str(e))
             continue
@@ -149,7 +150,7 @@ def main(args):
     
     idf = LWA1DataFile(filename)
     
-    jd = idf.get_info('start_time').jd
+    mjd = idf.get_info('start_time').mjd
     date = idf.get_info('start_time').datetime
     nFpO = len(antennas)
     sample_rate = idf.get_info('sample_rate')
@@ -200,7 +201,7 @@ def main(args):
     print("==")
     print("Station: %s" % station.name)
     print("Date observed: %s" % date)
-    print("Julian day: %.5f" % jd)
+    print("Julian day: %.5f" % mjd)
     print("Offset: %.3f s (%i frames)" % (args.offset, args.offset*sample_rate/512))
     print("Integration Time: %.3f s" % (512*nFrames/sample_rate))
     print("Number of integrations in file: %i" % nSets)


### PR DESCRIPTION
I'm not sure if you're accepting PRs. This PR is not complete yet but I thought I would try it out and see if you're ok with me issuing them.

Fixed in this PR:
=============

- Call to `FrameTimestamp.jd` -> `FrameTimestamp.mjd` since `jd` doesn't exist.
- A datetime setter was expecting a unix timestamp and receiving a FrameTimestamp.
- The sort override methdods in fitsidi.py's _UVData class self referenced the class with the class name (syntax that I believe should work or maybe just did in previous python versions). Explicitly self referencing with `self.__class__` fixed an error of `_UVData is not defined`.

Still needs work before PR is merged:
===========================

When I check the output of correlateTBN (`*.FITS_1`) with the imageIDI.py script I can't see anything (see image below). Now I'm trying to see whether this is an error with correlateTBN or with imageIDI.

<img width="593" alt="Screen Shot 2020-08-28 at 8 20 56 AM" src="https://user-images.githubusercontent.com/28943409/91584469-8db95e00-e907-11ea-9473-e6dcc17493ee.png">


I'll look at this again later and update this PR unless someone else gets there before me.