### PR TITLE
Support for the MCS `mindelay.txt` File

### DIFF
--- a/lsl/common/metabundle.py
+++ b/lsl/common/metabundle.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 
 from lsl.common import stations, sdm, sdf
 from lsl.common.mcs import *
-from lsl.common.dp import word_to_freq
+from lsl.common.dp import word_to_freq, FS
 from lsl.transform import Time
 from lsl.misc.lru_cache import lru_cache
 from lsl.common.color import colorfy
@@ -30,10 +30,11 @@ from lsl.misc import telemetry
 telemetry.track_module()
 
 
-__version__ = '1.0'
-__all__ = ['read_ses_file', 'read_obs_file', 'read_cs_file', 'get_sdm', 'get_station', 'get_session_metadata', 
-           'get_session_spec', 'get_observation_spec', 'get_sdf', 'get_command_script', 
-           'get_asp_configuration', 'get_asp_configuration_summary', 'is_valid']
+__version__ = '1.1'
+__all__ = ['read_ses_file', 'read_obs_file', 'read_cs_file', 'get_sdm', 'get_beamformer_min_delay',
+           'get_station', 'get_session_metadata', 'get_session_spec', 'get_observation_spec',
+           'get_sdf', 'get_command_script', 'get_asp_configuration', 'get_asp_configuration_summary',
+           'is_valid']
 
 # Regular expression for figuring out filenames
 filenameRE = re.compile(r'(?P<projectID>[a-zA-Z0-9]{1,8})_(?P<sessionID>\d+)(_(?P<obsID>\d+)(_(?P<obsOutcome>\d+))?)?.*\..*')
@@ -286,6 +287,33 @@ def get_sdm(tarname):
     return dynamic
 
 
+def get_beamformer_min_delay(tarname):
+    """
+    Given an MCS meta-data tarball, extract the minimum beamformer delay in 
+    samples and return it.  If no minimum delay can be found in the tarball, 
+    None is returned.
+    """
+    
+    with managed_mkdtemp(prefix='metadata-bundle-') as tempDir:
+        # Extract the mindelay.txt file.  If mindelay.txt cannot be found, None
+        # is returned via the try...except block.
+        tf = _open_tarball(tarname)
+        try:
+            ti = tf.getmember('mindelay.txt')
+        except KeyError:
+            return None
+        tf.extractall(path=tempDir, members=[ti,])
+        
+        # Parse the SDM file and build the SDM instance
+        with open(os.path.join(tempDir, 'mindelay.txt'), 'r') as fh:
+            try:
+                mindelay = int(fh.read(), 10)
+            except ValueError:
+                mindelay = None
+                
+    return mindelay
+
+
 def get_station(tarname, apply_sdm=True):
     """
     Given an MCS meta-data tarball, extract the information stored in the ssmif.dat 
@@ -309,6 +337,12 @@ def get_station(tarname, apply_sdm=True):
         # Read in the SSMIF
         station = stations.parse_ssmif(os.path.join(tempDir, 'ssmif.dat'))
         
+        # Get the beamformer minimum delay, if found
+        mindelay = get_beamformer_min_delay(tarname)
+        if mindelay is not None:
+            station.beamformer_min_delay_samples = mindelay
+            station.beamformer_min_delay = mindelay/FS
+            
         # Get the SDM (if we need to)
         if apply_sdm:
             dynamic = get_sdm(tarname)

--- a/lsl/common/metabundleADP.py
+++ b/lsl/common/metabundleADP.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 
 from lsl.common import stations, sdmADP, sdfADP
 from lsl.common.mcsADP import *
-from lsl.common.adp import word_to_freq
+from lsl.common.adp import word_to_freq, FS
 from lsl.transform import Time
 from lsl.misc.lru_cache import lru_cache
 from lsl.common.color import colorfy
@@ -30,10 +30,11 @@ from lsl.misc import telemetry
 telemetry.track_module()
 
 
-__version__ = '1.0'
-__all__ = ['read_ses_file', 'read_obs_file', 'read_cs_file', 'get_sdm', 'get_station', 'get_session_metadata', 
-           'get_session_spec', 'get_observation_spec', 'get_sdf', 'get_command_script', 
-           'get_asp_configuration', 'get_asp_configuration_summary', 'is_valid']
+__version__ = '1.1'
+__all__ = ['read_ses_file', 'read_obs_file', 'read_cs_file', 'get_sdm', 'get_beamformer_min_delay',
+           'get_station', 'get_session_metadata', 'get_session_spec', 'get_observation_spec',
+           'get_sdf', 'get_command_script', 'get_asp_configuration', 'get_asp_configuration_summary',
+           'is_valid']
 
 # Regular expression for figuring out filenames
 filenameRE = re.compile(r'(?P<projectID>[a-zA-Z0-9]{1,8})_(?P<sessionID>\d+)(_(?P<obsID>\d+)(_(?P<obsOutcome>\d+))?)?.*\..*')
@@ -253,6 +254,33 @@ def get_sdm(tarname):
     return dynamic
 
 
+def get_beamformer_min_delay(tarname):
+    """
+    Given an MCS meta-data tarball, extract the minimum beamformer delay in 
+    samples and return it.  If no minimum delay can be found in the tarball, 
+    None is returned.
+    """
+    
+    with managed_mkdtemp(prefix='metadata-bundle-') as tempDir:
+        # Extract the mindelay.txt file.  If mindelay.txt cannot be found, None
+        # is returned via the try...except block.
+        tf = _open_tarball(tarname)
+        try:
+            ti = tf.getmember('mindelay.txt')
+        except KeyError:
+            return None
+        tf.extractall(path=tempDir, members=[ti,])
+        
+        # Parse the SDM file and build the SDM instance
+        with open(os.path.join(tempDir, 'mindelay.txt'), 'r') as fh:
+            try:
+                mindelay = int(fh.read(), 10)
+            except ValueError:
+                mindelay = None
+                
+    return mindelay
+
+
 def get_station(tarname, apply_sdm=True):
     """
     Given an MCS meta-data tarball, extract the information stored in the ssmif.dat 
@@ -276,6 +304,12 @@ def get_station(tarname, apply_sdm=True):
         # Read in the SSMIF
         station = stations.parse_ssmif(os.path.join(tempDir, 'ssmif.dat'))
         
+        # Get the beamformer minimum delay, if found
+        mindelay = get_beamformer_min_delay(tarname)
+        if mindelay is not None:
+            station.beamformer_min_delay_samples = mindelay
+            station.beamformer_min_delay = mindelay/FS
+            
         # Get the SDM (if we need to)
         if apply_sdm:
             dynamic = get_sdm(tarname)

--- a/lsl/common/stations.py
+++ b/lsl/common/stations.py
@@ -29,7 +29,7 @@ from lsl.misc import telemetry
 telemetry.track_module()
 
 
-__version__ = '2.2'
+__version__ = '2.3'
 __all__ = ['geo_to_ecef', 'ecef_to_geo', 'LWAStation', 'Antenna', 'Stand', 'FEE', 'Cable', 'ARX', 'LSLInterface', 
         'parse_ssmif', 'lwa1', 'lwavl', 'lwana', 'lwasv',  'get_full_stations']
 
@@ -210,6 +210,10 @@ class LWAStation(ephem.Observer, LWAStationBase):
      * pols:  A list of polarizations
      * cables: A list of cables
     
+    .. versionchanged:: 2.1.0
+        Added new 'beamformer_min_delay' and 'beamformer_min_delay_samples' attributes
+        that can be used to help track the station's minimum beamformer delay.
+    
     .. versionchanged:: 1.2.0
         Added a new 'interface' attribute which provides referenves to various modules
         to help interface with the station.
@@ -233,6 +237,9 @@ class LWAStation(ephem.Observer, LWAStationBase):
         self.elev = elev
         self.pressure = 0.0
         self.horizon = 0.0
+        
+        self.beamformer_min_delay = None
+        self.beamformer_min_delay_samples = None
         
     def __str__(self):
         return "%s (%s) at lat: %.3f, lng: %.3f, elev: %.1f m with %i antennas" % (self.name, self.id, self.lat*180.0/numpy.pi, self.long*180.0/numpy.pi, self.elev, len(self.antennas))


### PR DESCRIPTION
Add support to `lsl.common.metabundle` and `lsl.common.metabundleADP` for the new MCS `mindelay.txt` file.