### PR TITLE
Added support for the new DR spectrometer modes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2.0.3
   * Fixed a problem with displaying lsl.reader.errors under Python3
+  * Added support for the XXCRCIYY, CRCI, and I DR spectrometer modes
 
 2.0.2
   * Added a -v/--lwasv option to correlateTBN.py and tbnSpectra.py

--- a/lsl/common/sdf.py
+++ b/lsl/common/sdf.py
@@ -2135,7 +2135,9 @@ class Session(object):
                 value = '{'+value
             if value[-1] != '}':
                 value = value+'}'
-        if value not in (None, '', '{Stokes=XXYY}', '{Stokes=IQUV}', '{Stokes=IV}'):
+        if value not in (None, '', 
+                         '{Stokes=XXYY}', '{Stokes=CRCI}', '{Stokes=XXCRCIYY}', 
+                         '{Stokes=I}', '{Stokes=IV}', '{Stokes=IQUV}'):
             raise ValueError("Invalid DR spectrometer mode '%s'" % value)
         self.spcMetatag = value
         

--- a/lsl/reader/drspec.py
+++ b/lsl/reader/drspec.py
@@ -109,9 +109,9 @@ class FrameHeader(FrameHeaderBase):
         if self.format & 0x01:
             products.append('XX')
         if self.format & 0x02:
-            products.append('XY')
+            products.append('XY_real')
         if self.format & 0x04:
-            products.append('YX')
+            products.append('XY_imag')
         if self.format & 0x08:
             products.append('YY')
             
@@ -227,7 +227,7 @@ class FramePayload(FramePayloadBase):
     def data(self):
         packed = []
         dtype = []
-        for p in ('XX', 'XY', 'YX', 'YY', 'I', 'Q', 'U', 'V'):
+        for p in ('XX', 'XY_real', 'XY_imag', 'YY', 'I', 'Q', 'U', 'V'):
             for t in (0, 1):
                 sub = getattr(self, "%s%i" % (p, t), None)
                 if sub is not None:
@@ -253,8 +253,8 @@ class Frame(FrameBase):
     .. versionchanged:: 0.6.0
         By default the data contained with in a frame is normalized by the number of
         fills (header.fills parameter).  For data products that are a function of more
-        than one primary input, i.e., XY* or I, the minimum fill of X and Y are used 
-        for normalization.
+        than one primary input, i.e., real(XY*) or I, the minimum fill of X and Y are 
+        used for normalization.
     """
     
     _header_class = FrameHeader


### PR DESCRIPTION
This PR adds support for the three new DR spectrometer modes:  XXCRCIYY, CRCI, and I.  In these definitions CR represents real(XY*), i.e, "**c**ross-hands **r**eal" and CI imag(XY*).  Although the data recorders use the CR/CI terminology LSL represents them as the more explicit "XY_real" and XY_imag".

This PR is associated with PRs for https://github.com/lwa-project/session_schedules and https://github.com/lwa-project/commissioning.  They will created soon but not merged until a version of LSL that supports these new modes has been released.