### PR TITLE
Gridder Fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
   * Cleaned up SDF and IDF rendering to make it faster
   * Added UCF_USERNAME_RE to lsl.common.idf/sdf/sdfADP to make it eaiser to validate UCF usernames 
   * Added support for querying the MCS `mindelays.txt` file in lsl.common.metabundle/metabundleADP
+  * Fixed a problem in lsl.imaging.utils.ImgW that lead to a shift in source position with frequency
 
 2.0.2
   * Added a -v/--lwasv option to correlateTBN.py and tbnSpectra.py

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
   * Added UCF_USERNAME_RE to lsl.common.idf/sdf/sdfADP to make it eaiser to validate UCF usernames 
   * Added support for querying the MCS `mindelays.txt` file in lsl.common.metabundle/metabundleADP
   * Fixed a problem in lsl.imaging.utils.ImgW that lead to a shift in source position with frequency
+  * Fixed a problem fitting a Gaussian to the point spread function in lsl.imaging.deconv
 
 2.0.2
   * Added a -v/--lwasv option to correlateTBN.py and tbnSpectra.py

--- a/lsl/imaging/deconv.py
+++ b/lsl/imaging/deconv.py
@@ -90,7 +90,7 @@ def _fit_gaussian(data):
         height = data.max()
         return height, x, y, width_x, width_y
 
-    def fitgaussian(data):
+    def fitgaussian(data, params=None):
         """
         Returns (height, x, y, width_x, width_y) the gaussian parameters 
         of a 2D distribution found by a fit
@@ -98,15 +98,22 @@ def _fit_gaussian(data):
         From:  http://wiki.scipy.org/Cookbook/FittingData
         """
         
-        params = moments(data)
+        if params is None:
+            params = moments(data)
         errorfunction = lambda p: numpy.ravel(gaussian(*p)(*numpy.indices(data.shape)) -
                                 data)
         p, success = leastsq(errorfunction, params)
         return p
         
-    params = fitgaussian(data)
-    fit = gaussian(*params)
-    
+    level = 0.5
+    params = None
+    while level > 0.1:
+        data_clipped = numpy.where(data/data.max() > level, data, 0)
+        params = fitgaussian(data_clipped, params=params)
+        level /= 2.0
+        
+    #fit = gaussian(*params)
+    #import pylab
     #pylab.matshow(data, cmap=pylab.cm.gist_earth_r)
     #pylab.contour(fit(*numpy.indices(data.shape)), cmap=pylab.cm.copper)
     #pylab.show()
@@ -169,7 +176,7 @@ def clean(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10,
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )
@@ -409,7 +416,7 @@ def clean_sources(aa, dataDict, aipyImg, srcs, input_image=None, size=80, res=0.
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )
@@ -699,7 +706,7 @@ def lsq(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10, p
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )

--- a/lsl/imaging/deconv.py
+++ b/lsl/imaging/deconv.py
@@ -169,7 +169,7 @@ def clean(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10,
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )
@@ -409,7 +409,7 @@ def clean_sources(aa, dataDict, aipyImg, srcs, input_image=None, size=80, res=0.
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )
@@ -472,7 +472,7 @@ def clean_sources(aa, dataDict, aipyImg, srcs, input_image=None, size=80, res=0.
             try:
                 peakParams = _fit_gaussian(working[peak_x-FWHM//2:peak_x+FWHM//2+1, peak_y-FWHM//2:peak_y+FWHM//2+1])
             except IndexError:
-                peakParams = [peakV, peak_x, peak_y]
+                peakParams = [peakV, FWHM//2, FWHM//2]
             peakVO = peakParams[0]
             peak_xO = peak_x - FWHM//2 + peakParams[1]
             peak_yO = peak_y - FWHM//2 + peakParams[2]
@@ -486,7 +486,7 @@ def clean_sources(aa, dataDict, aipyImg, srcs, input_image=None, size=80, res=0.
             try:
                 peakRA = _interpolate(RA, peak_xO, peak_yO)
             except IndexError:
-                peak_xO, peak_y0 = peak_x, peak_y
+                peak_xO, peak_yO = peak_x, peak_y
                 peakRA = RA[peak_x, peak_y]
             try:
                 peakDec = _interpolate(dec, peak_xO, peak_yO)
@@ -699,7 +699,7 @@ def lsq(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10, p
     
     # Fit a Guassian to the zenith beam response and use that for the restore beam
     beamCutout = psf[size//2:3*size//2, size//2:3*size//2]
-    beamCutout = numpy.where( beamCutout > 0.0, beamCutout, 0.0 )
+    beamCutout = numpy.where( beamCutout > 0.5, beamCutout, 0.0 )
     h, cx, cy, sx, sy = _fit_gaussian( beamCutout )
     gauGen = gaussian2d(1.0, size/2+cx, size/2+cy, sx, sy)
     FWHM = int( round( (sx+sy)/2.0 * 2.0*numpy.sqrt(2.0*numpy.log(2.0)) ) )
@@ -740,6 +740,7 @@ def lsq(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10, p
         pylab.ion()
         
     rChan = [chan[0], chan[-1]]
+    mdl *= modelToSim
     diff = img - mdl
     diffScaled = 0.0*diff/gain
     oldModel = mdl

--- a/lsl/imaging/deconv.py
+++ b/lsl/imaging/deconv.py
@@ -717,7 +717,7 @@ def lsq(aa, dataDict, aipyImg, input_image=None, size=80, res=0.50, wres=0.10, p
         img = input_image*1.0
         
     # Build the initial model
-    mdl = img*40
+    mdl = img*0 + img.max()
     mdl[numpy.where(mdl < 0)] = 0
     mdl[numpy.where(ra.mask == 1)] = 0
     

--- a/lsl/imaging/utils.py
+++ b/lsl/imaging/utils.py
@@ -1404,7 +1404,7 @@ class ImgWPlus(aipy.img.ImgW):
                 
             data = data*taper1*taper2
             
-        return aipy.img.recenter(ifft2Function(data).real.astype(numpy.float32), center)
+        return aipy.img.recenter(ifft2Function(data).real.astype(numpy.float32)/self.kern_corr, center)
         
     def image(self, center=(0,0), weighting='natural', local_fraction=0.5, robust=0.0, taper=(0.0, 0.0)):
         """Return the inverse FFT of the UV matrix, with the 0,0 point moved
@@ -1516,7 +1516,9 @@ def build_gridded_image(data_set, size=80, res=0.50, wres=0.10, pol='XX', chan=N
     if wgt.dtype != numpy.complex64:
         wgt = wgt.astype(numpy.complex64)
         
-    im.uv, im.bm[0] = WProjection(u, v, w, vis, wgt, size, numpy.float64(res), numpy.float64(wres))
+    im.uv, im.bm[0], im.kern_corr = WProjection(u, v, w, vis, wgt, size, numpy.float64(res), numpy.float64(wres))
+    im.kern_corr.shape = (im.kern_corr.size,1)
+    im.kern_corr = im.kern_corr * im.kern_corr.T
     
     if not verbose:
         sys.stdout.close()

--- a/lsl/imaging/utils.py
+++ b/lsl/imaging/utils.py
@@ -1517,8 +1517,6 @@ def build_gridded_image(data_set, size=80, res=0.50, wres=0.10, pol='XX', chan=N
         wgt = wgt.astype(numpy.complex64)
         
     im.uv, im.bm[0], im.kern_corr = WProjection(u, v, w, vis, wgt, size, numpy.float64(res), numpy.float64(wres))
-    im.kern_corr.shape = (im.kern_corr.size,1)
-    im.kern_corr = im.kern_corr * im.kern_corr.T
     
     if not verbose:
         sys.stdout.close()


### PR DESCRIPTION
This PR updates the `lsl.imaging.util.ImgWPlus` class and the `lsl.imaging._gridder` module to address a dependence of source position on frequency found by @nsbruce.  This problem was fixed by (1) switching over to the same sinc-windowed Kaiser-Bessel function used by [wsclean](https://gitlab.com/aroffringa/wsclean/) in `_gridder` and (2) applying a correction for the gridding kernel to the final image in `ImgWPlus`.