### PR TITLE
Add support for TRK_LUN

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 2.1.6
  * Updated for Python 3.10
  * Cleaned up the naming of the tutorial notebooks
+ * Added support for observing with TRK_LUN
 
 2.1.5
  * Fixed a few more problems with the new cache management

--- a/lsl/common/sdfADP.py
+++ b/lsl/common/sdfADP.py
@@ -230,6 +230,14 @@ class Project(_Project):
                 output += "OBS_FREQ2+       %.9f MHz\n" % (obs.frequency2/1e6,)
                 output += "OBS_BW           %i\n" % (obs.filter,)
                 output += "OBS_BW+          %s\n" % (self._render_bandwidth(obs.filter, obs.filter_codes),)
+            elif obs.mode == 'TRK_LUN':
+                output += "OBS_B            %s\n" % (obs.beam,)
+                output += "OBS_FREQ1        %i\n" % (obs.freq1,)
+                output += "OBS_FREQ1+       %.9f MHz\n" % (obs.frequency1/1e6,)
+                output += "OBS_FREQ2        %i\n" % (obs.freq2,)
+                output += "OBS_FREQ2+       %.9f MHz\n" % (obs.frequency2/1e6,)
+                output += "OBS_BW           %i\n" % (obs.filter,)
+                output += "OBS_BW+          %s\n" % (self._render_bandwidth(obs.filter, obs.filter_codes),)
             elif obs.mode == 'STEPPED':
                 output += "OBS_BW           %i\n" % (obs.filter,)
                 output += "OBS_BW+          %s\n" % (self._render_bandwidth(obs.filter, obs.filter_codes),)
@@ -545,6 +553,8 @@ def _parse_create_obs_object(obs_temp, beam_temps=None, verbose=False):
         obsOut = Solar(obs_temp['name'], obs_temp['target'], utcString, durString, f1, f2, obs_temp['filter'], gain=obs_temp['gain'], max_snr=obs_temp['MaxSNR'], comments=obs_temp['comments'])
     elif mode == 'TRK_JOV':
         obsOut = Jovian(obs_temp['name'], obs_temp['target'], utcString, durString, f1, f2, obs_temp['filter'], gain=obs_temp['gain'], max_snr=obs_temp['MaxSNR'], comments=obs_temp['comments'])
+    elif mode == 'TRK_LUN':
+        obsOut = Lunar(obs_temp['name'], obs_temp['target'], utcString, durString, f1, f2, obs_temp['filter'], gain=obs_temp['gain'], max_snr=obs_temp['MaxSNR'], comments=obs_temp['comments'])
     elif mode == 'STEPPED':
         if verbose:
             print("[%i] -> found %i steps" % (os.getpid(), len(beam_temps)))

--- a/lsl/common/sdfADP.py
+++ b/lsl/common/sdfADP.py
@@ -67,14 +67,14 @@ from lsl.reader.tbf import FRAME_SIZE as TBFSize
 
 from lsl.common.sdf import Observer, ProjectOffice
 from lsl.common.sdf import Project as _Project, Session as _Session
-from lsl.common.sdf import UCF_USERNAME_RE, parse_time, Observation, TBN, DRX, Solar, Jovian, Stepped, BeamStep
+from lsl.common.sdf import UCF_USERNAME_RE, parse_time, Observation, TBN, DRX, Solar, Jovian, Lunar, Stepped, BeamStep
 
 from lsl.misc import telemetry
 telemetry.track_module()
 
 
 __version__ = '1.2'
-__all__ = ['UCF_USERNAME_RE', 'parse_time', 'Observer', 'ProjectOffice', 'Project', 'Session', 'Observation', 'TBF', 'TBN', 'DRX', 'Solar', 'Jovian', 'Stepped', 'BeamStep', 'parse_sdf',  'get_observation_start_stop', 'is_valid']
+__all__ = ['UCF_USERNAME_RE', 'parse_time', 'Observer', 'ProjectOffice', 'Project', 'Session', 'Observation', 'TBF', 'TBN', 'DRX', 'Solar', 'Jovian', 'Lunar', 'Stepped', 'BeamStep', 'parse_sdf',  'get_observation_start_stop', 'is_valid']
 
 
 _UTC = pytz.utc

--- a/lsl/data/tests/lun-sdf.txt
+++ b/lsl/data/tests/lun-sdf.txt
@@ -1,0 +1,50 @@
+PI_ID            1
+PI_NAME          Ellingson, Steven
+
+PROJECT_ID       TPSS0001
+PROJECT_TITLE    Project Title
+PROJECT_REMPI    Project REMPI
+
+SESSION_ID       1
+SESSION_TITLE    tp_session_sch SDF test #1
+SESSION_REMPI    Test SDF consisting of 2 short TRK_RADEC observations
+SESSION_DRX_BEAM 1
+
+OBS_ID           1
+OBS_TITLE        Observation 1 Title
+OBS_TARGET       Observation 1 Target
+OBS_REMPI        Observation 1 REMPI
+OBS_START_MJD    55616
+OBS_START_MPM    0
+OBS_START        UTC 2011 02 24 00:00:00.000000
+OBS_DUR          10000
+OBS_DUR+         00:00:10.000
+OBS_MODE         TRK_LUN
+OBS_B            SIMPLE
+OBS_FREQ1        438261968
+OBS_FREQ1+       19.999999955 MHz
+OBS_FREQ2        1928352663
+OBS_FREQ2+       87.999999977 MHz
+OBS_BW           7
+OBS_BW+          19.600 MHz
+
+OBS_ID           2
+OBS_TITLE        Observation 2 Title
+OBS_TARGET       Observation 1 Target
+OBS_REMPI        Observation 1 REMPI
+OBS_REMPO        Estimated data volume for this observation is 790.1 MB
+OBS_START_MJD    55616
+OBS_START_MPM    10000
+OBS_START        UTC 2011 02 24 00:00:10.000000
+OBS_DUR          10000
+OBS_DUR+         00:00:10.000
+OBS_MODE         TRK_LUN
+OBS_B            SIMPLE
+OBS_FREQ1        832697741
+OBS_FREQ1+       37.999999997 MHz
+OBS_FREQ2        1621569285
+OBS_FREQ2+       73.999999990 MHz
+OBS_BW           7
+OBS_BW+          19.600 MHz
+
+

--- a/lsl/data/tests/lun-sdf.txt
+++ b/lsl/data/tests/lun-sdf.txt
@@ -14,9 +14,9 @@ OBS_ID           1
 OBS_TITLE        Observation 1 Title
 OBS_TARGET       Observation 1 Target
 OBS_REMPI        Observation 1 REMPI
-OBS_START_MJD    55616
-OBS_START_MPM    0
-OBS_START        UTC 2011 02 24 00:00:00.000000
+OBS_START_MJD    55615
+OBS_START_MPM    43200000
+OBS_START        UTC 2011 02 23 12:00:00.000000
 OBS_DUR          10000
 OBS_DUR+         00:00:10.000
 OBS_MODE         TRK_LUN
@@ -33,9 +33,9 @@ OBS_TITLE        Observation 2 Title
 OBS_TARGET       Observation 1 Target
 OBS_REMPI        Observation 1 REMPI
 OBS_REMPO        Estimated data volume for this observation is 790.1 MB
-OBS_START_MJD    55616
-OBS_START_MPM    10000
-OBS_START        UTC 2011 02 24 00:00:10.000000
+OBS_START_MJD    55615
+OBS_START_MPM    43210000
+OBS_START        UTC 2011 02 23 12:00:10.000000
 OBS_DUR          10000
 OBS_DUR+         00:00:10.000
 OBS_MODE         TRK_LUN
@@ -46,5 +46,3 @@ OBS_FREQ2        1621569285
 OBS_FREQ2+       73.999999990 MHz
 OBS_BW           7
 OBS_BW+          19.600 MHz
-
-

--- a/tests/test_sdf.py
+++ b/tests/test_sdf.py
@@ -39,6 +39,7 @@ tbnFile = os.path.join(DATA_BUILD, 'tests', 'tbn-sdf.txt')
 drxFile = os.path.join(DATA_BUILD, 'tests', 'drx-sdf.txt')
 solFile = os.path.join(DATA_BUILD, 'tests', 'sol-sdf.txt')
 jovFile = os.path.join(DATA_BUILD, 'tests', 'jov-sdf.txt')
+lunFile = os.path.join(DATA_BUILD, 'tests', 'lun-sdf.txt')
 stpFile = os.path.join(DATA_BUILD, 'tests', 'stp-sdf.txt')
 spcFile = os.path.join(DATA_BUILD, 'tests', 'spc-sdf.txt')
 tbfFile = os.path.join(DATA_BUILD, 'tests', 'tbf-sdf.txt')
@@ -732,6 +733,90 @@ class sdf_tests(unittest.TestCase):
         """Test various TRK_JOV SDF errors."""
         
         project = sdf.parse_sdf(jovFile)
+        
+        # Bad beam
+        project.sessions[0].drx_beam = 6
+        self.assertFalse(project.validate())
+        
+        # No beam (this is allowed now)
+        project.sessions[0].drx_beam = -1
+        self.assertTrue(project.validate())
+        
+        # Bad filter
+        project.sessions[0].observations[0].filter = 10
+        self.assertFalse(project.validate())
+        
+        # Bad frequency
+        project.sessions[0].observations[0].filter = 7
+        project.sessions[0].observations[0].frequency1 = 90.0e6
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+        project.sessions[0].observations[0].frequency1 = 38.0e6
+        project.sessions[0].observations[0].frequency2 = 90.0e6
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+        # Bad duration
+        project.sessions[0].observations[0].frequency2 = 38.0e6
+        project.sessions[0].observations[0].duration = '96:00:00.000'
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+    ### DRX - TRK_LUN ###
+    
+    def test_lun_parse(self):
+        """Test reading in a TRK_LUN SDF file."""
+        
+        project = sdf.parse_sdf(lunFile)
+        
+        # Basic file structure
+        self.assertEqual(len(project.sessions), 1)
+        self.assertEqual(len(project.sessions[0].observations), 2)
+        
+        # Observational setup - 1
+        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[0].mpm,      0)
+        self.assertEqual(project.sessions[0].observations[0].dur,  10000)
+        self.assertEqual(project.sessions[0].observations[0].freq1,  438261968)
+        self.assertEqual(project.sessions[0].observations[0].freq2, 1928352663)
+        self.assertEqual(project.sessions[0].observations[0].filter,   7)
+        
+        # Observational setup - 2
+        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
+        self.assertEqual(project.sessions[0].observations[1].dur,  10000)
+        self.assertEqual(project.sessions[0].observations[1].freq1,  832697741)
+        self.assertEqual(project.sessions[0].observations[1].freq2, 1621569285)
+        self.assertEqual(project.sessions[0].observations[1].filter,   7)
+        
+    def test_lun_update(self):
+        """Test updating TRK_LUN values."""
+        
+        project = sdf.parse_sdf(lunFile)
+        project.sessions[0].observations[1].start = "MST 2011 Feb 23 17:00:15"
+        project.sessions[0].observations[1].duration = timedelta(seconds=15)
+        project.sessions[0].observations[1].frequency1 = 75e6
+        project.sessions[0].observations[1].frequency2 = 76e6
+        
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  15000)
+        self.assertEqual(project.sessions[0].observations[1].dur,  15000)
+        self.assertEqual(project.sessions[0].observations[1].freq1, 1643482384)
+        self.assertEqual(project.sessions[0].observations[1].freq2, 1665395482)
+        
+    def test_lun_write(self):
+        """Test writing a TRK_LUN SDF file."""
+        
+        project = sdf.parse_sdf(lunFile)
+        out = project.render()
+        
+    def test_lun_errors(self):
+        """Test various TRK_LUN SDF errors."""
+        
+        project = sdf.parse_sdf(lunFile)
         
         # Bad beam
         project.sessions[0].drx_beam = 6

--- a/tests/test_sdf.py
+++ b/tests/test_sdf.py
@@ -775,7 +775,7 @@ class sdf_tests(unittest.TestCase):
         self.assertEqual(len(project.sessions[0].observations), 2)
         
         # Observational setup - 1
-        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_LUN')
         self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
         self.assertEqual(project.sessions[0].observations[0].mpm,      0)
         self.assertEqual(project.sessions[0].observations[0].dur,  10000)
@@ -784,7 +784,7 @@ class sdf_tests(unittest.TestCase):
         self.assertEqual(project.sessions[0].observations[0].filter,   7)
         
         # Observational setup - 2
-        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_LUN')
         self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
         self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
         self.assertEqual(project.sessions[0].observations[1].dur,  10000)

--- a/tests/test_sdf.py
+++ b/tests/test_sdf.py
@@ -776,8 +776,8 @@ class sdf_tests(unittest.TestCase):
         
         # Observational setup - 1
         self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_LUN')
-        self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[0].mpm,      0)
+        self.assertEqual(project.sessions[0].observations[0].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[0].mpm,  43200000)
         self.assertEqual(project.sessions[0].observations[0].dur,  10000)
         self.assertEqual(project.sessions[0].observations[0].freq1,  438261968)
         self.assertEqual(project.sessions[0].observations[0].freq2, 1928352663)
@@ -785,8 +785,8 @@ class sdf_tests(unittest.TestCase):
         
         # Observational setup - 2
         self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_LUN')
-        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  43210000)
         self.assertEqual(project.sessions[0].observations[1].dur,  10000)
         self.assertEqual(project.sessions[0].observations[1].freq1,  832697741)
         self.assertEqual(project.sessions[0].observations[1].freq2, 1621569285)
@@ -796,13 +796,13 @@ class sdf_tests(unittest.TestCase):
         """Test updating TRK_LUN values."""
         
         project = sdf.parse_sdf(lunFile)
-        project.sessions[0].observations[1].start = "MST 2011 Feb 23 17:00:15"
+        project.sessions[0].observations[1].start = "MST 2011 Feb 23 5:00:15"
         project.sessions[0].observations[1].duration = timedelta(seconds=15)
         project.sessions[0].observations[1].frequency1 = 75e6
         project.sessions[0].observations[1].frequency2 = 76e6
         
-        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[1].mpm,  15000)
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  43215000)
         self.assertEqual(project.sessions[0].observations[1].dur,  15000)
         self.assertEqual(project.sessions[0].observations[1].freq1, 1643482384)
         self.assertEqual(project.sessions[0].observations[1].freq2, 1665395482)

--- a/tests/test_sdf_adp.py
+++ b/tests/test_sdf_adp.py
@@ -708,8 +708,8 @@ class sdf_adp_tests(unittest.TestCase):
         
         # Observational setup - 1
         self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_LUN')
-        self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[0].mpm,      0)
+        self.assertEqual(project.sessions[0].observations[0].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[0].mpm,  43200000)
         self.assertEqual(project.sessions[0].observations[0].dur,  10000)
         self.assertEqual(project.sessions[0].observations[0].freq1,  438261968)
         self.assertEqual(project.sessions[0].observations[0].freq2, 1928352663)
@@ -717,8 +717,8 @@ class sdf_adp_tests(unittest.TestCase):
         
         # Observational setup - 2
         self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_LUN')
-        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  43210000)
         self.assertEqual(project.sessions[0].observations[1].dur,  10000)
         self.assertEqual(project.sessions[0].observations[1].freq1,  832697741)
         self.assertEqual(project.sessions[0].observations[1].freq2, 1621569285)
@@ -728,13 +728,13 @@ class sdf_adp_tests(unittest.TestCase):
         """Test updating TRK_LUN values."""
         
         project = sdfADP.parse_sdf(lunFile)
-        project.sessions[0].observations[1].start = "MST 2011 Feb 23 17:00:15"
+        project.sessions[0].observations[1].start = "MST 2011 Feb 23 5:00:15"
         project.sessions[0].observations[1].duration = timedelta(seconds=15)
         project.sessions[0].observations[1].frequency1 = 75e6
         project.sessions[0].observations[1].frequency2 = 76e6
         
-        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
-        self.assertEqual(project.sessions[0].observations[1].mpm,  15000)
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55615)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  43215000)
         self.assertEqual(project.sessions[0].observations[1].dur,  15000)
         self.assertEqual(project.sessions[0].observations[1].freq1, 1643482384)
         self.assertEqual(project.sessions[0].observations[1].freq2, 1665395482)

--- a/tests/test_sdf_adp.py
+++ b/tests/test_sdf_adp.py
@@ -707,7 +707,7 @@ class sdf_adp_tests(unittest.TestCase):
         self.assertEqual(len(project.sessions[0].observations), 2)
         
         # Observational setup - 1
-        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_LUN')
         self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
         self.assertEqual(project.sessions[0].observations[0].mpm,      0)
         self.assertEqual(project.sessions[0].observations[0].dur,  10000)
@@ -716,7 +716,7 @@ class sdf_adp_tests(unittest.TestCase):
         self.assertEqual(project.sessions[0].observations[0].filter,   7)
         
         # Observational setup - 2
-        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_LUN')
         self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
         self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
         self.assertEqual(project.sessions[0].observations[1].dur,  10000)

--- a/tests/test_sdf_adp.py
+++ b/tests/test_sdf_adp.py
@@ -37,6 +37,7 @@ tbnFile = os.path.join(DATA_BUILD, 'tests', 'tbn-sdf.txt')
 drxFile = os.path.join(DATA_BUILD, 'tests', 'drx-sdf.txt')
 solFile = os.path.join(DATA_BUILD, 'tests', 'sol-sdf.txt')
 jovFile = os.path.join(DATA_BUILD, 'tests', 'jov-sdf.txt')
+lunFile = os.path.join(DATA_BUILD, 'tests', 'lun-sdf.txt')
 stpFile = os.path.join(DATA_BUILD, 'tests', 'stp-sdf.txt')
 spcFile = os.path.join(DATA_BUILD, 'tests', 'spc-sdf.txt')
 tbfFile = os.path.join(DATA_BUILD, 'tests', 'tbf-sdf.txt')
@@ -664,6 +665,90 @@ class sdf_adp_tests(unittest.TestCase):
         """Test various TRK_JOV SDF errors."""
         
         project = sdfADP.parse_sdf(jovFile)
+        
+        # Bad beam
+        project.sessions[0].drx_beam = 6
+        self.assertFalse(project.validate())
+        
+        # No beam (this is allowed now)
+        project.sessions[0].drx_beam = -1
+        self.assertTrue(project.validate())
+        
+        # Bad filter
+        project.sessions[0].observations[0].filter = 8
+        self.assertFalse(project.validate())
+        
+        # Bad frequency
+        project.sessions[0].observations[0].filter = 6
+        project.sessions[0].observations[0].frequency1 = 90.0e6
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+        project.sessions[0].observations[0].frequency1 = 38.0e6
+        project.sessions[0].observations[0].frequency2 = 90.0e6
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+        # Bad duration
+        project.sessions[0].observations[0].frequency2 = 38.0e6
+        project.sessions[0].observations[0].duration = '96:00:00.000'
+        project.sessions[0].observations[0].update()
+        self.assertFalse(project.validate())
+        
+    ### DRX - TRK_LUN ###
+    
+    def test_lun_parse(self):
+        """Test reading in a TRK_LUN SDF file."""
+        
+        project = sdfADP.parse_sdf(lunFile)
+        
+        # Basic file structure
+        self.assertEqual(len(project.sessions), 1)
+        self.assertEqual(len(project.sessions[0].observations), 2)
+        
+        # Observational setup - 1
+        self.assertEqual(project.sessions[0].observations[0].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[0].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[0].mpm,      0)
+        self.assertEqual(project.sessions[0].observations[0].dur,  10000)
+        self.assertEqual(project.sessions[0].observations[0].freq1,  438261968)
+        self.assertEqual(project.sessions[0].observations[0].freq2, 1928352663)
+        self.assertEqual(project.sessions[0].observations[0].filter,   7)
+        
+        # Observational setup - 2
+        self.assertEqual(project.sessions[0].observations[1].mode, 'TRK_JOV')
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  10000)
+        self.assertEqual(project.sessions[0].observations[1].dur,  10000)
+        self.assertEqual(project.sessions[0].observations[1].freq1,  832697741)
+        self.assertEqual(project.sessions[0].observations[1].freq2, 1621569285)
+        self.assertEqual(project.sessions[0].observations[1].filter,   7)
+        
+    def test_lun_update(self):
+        """Test updating TRK_LUN values."""
+        
+        project = sdfADP.parse_sdf(lunFile)
+        project.sessions[0].observations[1].start = "MST 2011 Feb 23 17:00:15"
+        project.sessions[0].observations[1].duration = timedelta(seconds=15)
+        project.sessions[0].observations[1].frequency1 = 75e6
+        project.sessions[0].observations[1].frequency2 = 76e6
+        
+        self.assertEqual(project.sessions[0].observations[1].mjd,  55616)
+        self.assertEqual(project.sessions[0].observations[1].mpm,  15000)
+        self.assertEqual(project.sessions[0].observations[1].dur,  15000)
+        self.assertEqual(project.sessions[0].observations[1].freq1, 1643482384)
+        self.assertEqual(project.sessions[0].observations[1].freq2, 1665395482)
+        
+    def test_lun_write(self):
+        """Test writing a TRK_LUN SDF file."""
+        
+        project = sdfADP.parse_sdf(lunFile)
+        out = project.render()
+        
+    def test_lun_errors(self):
+        """Test various TRK_LUN SDF errors."""
+        
+        project = sdfADP.parse_sdf(lunFile)
         
         # Bad beam
         project.sessions[0].drx_beam = 6


### PR DESCRIPTION
This PR adds support for the new beamforming mode `TRK_LUN` which tracks the Moon.