### PR TITLE
Add support for triggered voltage buffer dumps from OVRO-LWA

### DIFF
--- a/lsl/reader/gofast.c
+++ b/lsl/reader/gofast.c
@@ -86,14 +86,14 @@ static void initLWALUTs(void) {
 */
 
 static PyMethodDef GoFastMethods[] = {
-    {"read_tbw",    (PyCFunction) read_tbw,    METH_VARARGS,               read_tbw_doc   }, 
-    {"read_tbn",    (PyCFunction) read_tbn,    METH_VARARGS,               read_tbn_doc   }, 
-    {"read_drx",    (PyCFunction) read_drx,    METH_VARARGS,               read_drx_doc   }, 
-    {"read_drspec", (PyCFunction) read_drspec, METH_VARARGS,               read_drspec_doc},
-    {"read_vdif",   (PyCFunction) read_vdif,   METH_VARARGS|METH_KEYWORDS, read_vdif_doc  }, 
-    {"read_tbf",    (PyCFunction) read_tbf,    METH_VARARGS,               read_tbf_doc   }, 
-    {"read_cor",    (PyCFunction) read_cor,    METH_VARARGS,               read_cor_doc   }, 
-    {"read_ovro",   (PyCFunction) read_ovro,   METH_VARARGS,               read_ovro_doc  }, 
+    {"read_tbw",       (PyCFunction) read_tbw,       METH_VARARGS,               read_tbw_doc      }, 
+    {"read_tbn",       (PyCFunction) read_tbn,       METH_VARARGS,               read_tbn_doc      }, 
+    {"read_drx",       (PyCFunction) read_drx,       METH_VARARGS,               read_drx_doc      }, 
+    {"read_drspec",    (PyCFunction) read_drspec,    METH_VARARGS,               read_drspec_doc   },
+    {"read_vdif",      (PyCFunction) read_vdif,      METH_VARARGS|METH_KEYWORDS, read_vdif_doc     }, 
+    {"read_tbf",       (PyCFunction) read_tbf,       METH_VARARGS,               read_tbf_doc      }, 
+    {"read_cor",       (PyCFunction) read_cor,       METH_VARARGS,               read_cor_doc      }, 
+    {"read_ovro_spec", (PyCFunction) read_ovro_spec, METH_VARARGS,               read_ovro_spec_doc}, 
     {NULL,          NULL,                      0,                          NULL           }
 };
 
@@ -167,7 +167,7 @@ MOD_INIT(_gofast) {
     PyList_Append(all, PyString_FromString("read_vdif"));
     PyList_Append(all, PyString_FromString("read_tbf"));
     PyList_Append(all, PyString_FromString("read_cor"));
-    PyList_Append(all, PyString_FromString("read_ovro"));
+    PyList_Append(all, PyString_FromString("read_ovro_spec"));
     PyList_Append(all, PyString_FromString("SyncError"));
     PyList_Append(all, PyString_FromString("EOFError"));
     PyList_Append(all, PyString_FromString("NCHAN_COR"));

--- a/lsl/reader/gofast.c
+++ b/lsl/reader/gofast.c
@@ -41,6 +41,7 @@ short int tbw4LUT[256][2];
 float tbnLUT[256];
 float drxLUT[256][2];
 float tbfLUT[256][2];
+float ovroLUT[256][2];
 
 static void initLWALUTs(void) {
     // Look-up table inialization function from the VDIFIO library
@@ -63,7 +64,7 @@ static void initLWALUTs(void) {
         tbnLUT[i] -= ((i&128)<<1);
     }
     
-    // DRX & TBF
+    // DRX & TBF & OVRO
     for(i=0; i<256; i++) {
         for(j=0; j<2; j++) {
             t = (i >> 4*(1-j)) & 15;
@@ -72,6 +73,9 @@ static void initLWALUTs(void) {
             
             tbfLUT[i][j] = t;
             tbfLUT[i][j] -= ((t&8)<<1);
+            
+            ovroLUT[i][j] = t;
+            ovroLUT[i][j] -= ((t&8)<<1);
         }
     }
 }
@@ -89,6 +93,7 @@ static PyMethodDef GoFastMethods[] = {
     {"read_vdif",   (PyCFunction) read_vdif,   METH_VARARGS|METH_KEYWORDS, read_vdif_doc  }, 
     {"read_tbf",    (PyCFunction) read_tbf,    METH_VARARGS,               read_tbf_doc   }, 
     {"read_cor",    (PyCFunction) read_cor,    METH_VARARGS,               read_cor_doc   }, 
+    {"read_ovro",   (PyCFunction) read_ovro,   METH_VARARGS,               read_ovro_doc  }, 
     {NULL,          NULL,                      0,                          NULL           }
 };
 
@@ -162,6 +167,7 @@ MOD_INIT(_gofast) {
     PyList_Append(all, PyString_FromString("read_vdif"));
     PyList_Append(all, PyString_FromString("read_tbf"));
     PyList_Append(all, PyString_FromString("read_cor"));
+    PyList_Append(all, PyString_FromString("read_ovro"));
     PyList_Append(all, PyString_FromString("SyncError"));
     PyList_Append(all, PyString_FromString("EOFError"));
     PyList_Append(all, PyString_FromString("NCHAN_COR"));

--- a/lsl/reader/ovro.c
+++ b/lsl/reader/ovro.c
@@ -19,7 +19,7 @@ PyObject *ovro_size   = NULL;
 
 
 PyObject *read_ovro(PyObject *self, PyObject *args) {
-    PyObject *ph, *buffer, *output, *frame, *fHeader, *fPayload, *temp;
+    PyObject *ph, *buffer, *output;
     PyArrayObject *data;
     long i;
     int ntime, nchan, nstand, npol;

--- a/lsl/reader/ovro.c
+++ b/lsl/reader/ovro.c
@@ -1,0 +1,91 @@
+#include "Python.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <complex.h>
+
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL gofast_ARRAY_API
+#include "numpy/arrayobject.h"
+
+#include "readers.h"
+
+/*
+  OVRO-LWA triggered voltage buffer dump file data section reader
+*/
+
+PyObject *ovro_method = NULL;
+PyObject *ovro_size   = NULL;
+
+
+PyObject *read_ovro(PyObject *self, PyObject *args) {
+    PyObject *ph, *buffer, *output, *frame, *fHeader, *fPayload, *temp;
+    PyArrayObject *data;
+    long i;
+    int ntime, nchan, nstand, npol;
+    
+    if(!PyArg_ParseTuple(args, "Oiiii", &ph, &ntime, &nchan, &nstand, &npol)) {
+        PyErr_Format(PyExc_RuntimeError, "Invalid parameters");
+        return NULL;
+    }
+    
+    // Create the output data array
+    npy_intp dims[4];
+    // 4+4-bit Data -> 6144 samples in the data section as 12 channels, 256 stands, and 2 pols.
+    dims[0] = (npy_intp) ntime;
+    dims[1] = (npy_intp) nchan;
+    dims[2] = (npy_intp) nstand;
+    dims[3] = (npy_intp) npol;
+    data = (PyArrayObject*) PyArray_ZEROS(4, dims, NPY_COMPLEX64, 0);
+    if(data == NULL) {
+        PyErr_Format(PyExc_MemoryError, "Cannot create output array");
+        Py_XDECREF(data);
+        return NULL;
+    }
+
+    // Read from the file
+    if( ovro_method == NULL ) {
+        ovro_method = Py_BuildValue("s", "read");
+        ovro_size = Py_BuildValue("i", ntime*nchan*nstand*npol*1);
+    }
+    buffer = PyObject_CallMethodObjArgs(ph, ovro_method, ovro_size, NULL);
+    if( buffer == NULL ) {
+        if( PyObject_HasAttrString(ph, "read") ) {
+            PyErr_Format(PyExc_IOError, "An error occured while reading from the file");
+        } else {
+            PyErr_Format(PyExc_AttributeError, "Object does not have a read() method");
+        }
+        Py_XDECREF(data);
+        return NULL;
+    } else if( PyString_GET_SIZE(buffer) != (ntime*nchan*nstand*npol*1) ) {
+        PyErr_Format(EOFError, "End of file encountered during filehandle read");
+        Py_XDECREF(data);
+        Py_XDECREF(buffer);
+        return NULL;
+    }
+    
+    Py_BEGIN_ALLOW_THREADS
+    
+    // Fill the data array
+    const float *fp;
+    float complex *a;
+    a = (float complex *) PyArray_DATA(data);
+    for(i=0; i<ntime*nchan*nstand*npol; i++) {
+        fp = ovroLUT[ (PyString_AS_STRING(buffer))[i] ];
+        *(a + i) = fp[0] + _Complex_I * fp[1];
+    }
+    
+    Py_END_ALLOW_THREADS
+    
+    output = Py_BuildValue("O", PyArray_Return(data));
+    
+    Py_XDECREF(buffer);
+    Py_XDECREF(data);
+    
+    return output;
+}
+
+char read_ovro_doc[] = PyDoc_STR(\
+"Function to read in the data section of a OVRO-LWA triggered voltage buffer\n\
+dump file and return it as a 4-D numpy array.\n\
+");

--- a/lsl/reader/ovro.c
+++ b/lsl/reader/ovro.c
@@ -18,7 +18,7 @@ PyObject *ovro_method = NULL;
 PyObject *ovro_size   = NULL;
 
 
-PyObject *read_ovro(PyObject *self, PyObject *args) {
+PyObject *read_ovro_spec(PyObject *self, PyObject *args) {
     PyObject *ph, *buffer, *output;
     PyArrayObject *data;
     long i;
@@ -84,7 +84,7 @@ PyObject *read_ovro(PyObject *self, PyObject *args) {
     return output;
 }
 
-char read_ovro_doc[] = PyDoc_STR(\
+char read_ovro_spec_doc[] = PyDoc_STR(\
 "Function to read in a single set of spectra from the data section of a OVRO-LWA\n\
 triggered voltage buffer dump file and return it as a 3-D numpy.complex64 array.\n\
 ");

--- a/lsl/reader/ovro.py
+++ b/lsl/reader/ovro.py
@@ -47,10 +47,8 @@ __version__ = '0.1'
 class FrameHeader(FrameHeaderBase):
     _header_attrs = ['timetag', 'seq0', 'sync_time', 'pipeline_id', 'first_chan', 'nchan']
     
-    def __init__(self, timetag=None, seq0=None, sync_time=None, pipeline_id=None, first_chan=None, nchan=None):
+    def __init__(self, timetag=None, pipeline_id=None, first_chan=None, nchan=None):
         self.timetag = timetag
-        self.seq0 = seq0
-        self.sync_time = sync_time
         self.pipeline_id = pipeline_id
         self.first_chan = first_chan
         self.nchan = nchan
@@ -64,7 +62,7 @@ class FrameHeader(FrameHeaderBase):
         `lsl.reader.base.FrameTimestamp` instance.
         """
         
-        return FrameTimestamp.from_dp_timetag(self.sync_time*196000000 + self.timetag*8192)
+        return FrameTimestamp.from_dp_timetag(self.timetag)
         
     @property
     def channel_freqs(self):
@@ -161,9 +159,7 @@ def read_frame(filehandle, verbose=False):
         data = read_ovro_spec(filehandle, nchan, nstand, npol)
         
         newFrame = Frame()
-        newFrame.header.timetag = header['time_tag'] + delta_timetag
-        newFrame.header.seq0 = header['seq0']
-        newFrame.header.sync_time = header['sync_time']
+        newFrame.header.timetag = (int(header['seq']) + delta_timetag) * 8192
         newFrame.header.pipeline_id = header['pipeline_id']
         newFrame.header.first_chan = header['chan0']
         newFrame.header.nchan = nchan
@@ -180,6 +176,9 @@ def get_frames_per_obs(filehandle):
     frames per observation.
     """
     
+    # Housekeeping
+    _clean_header_cache()
+    
     return 1
 
 
@@ -188,6 +187,9 @@ def get_channel_count(filehandle):
     Find out the total number of channels that are present.  Return the number
     of channels found.
     """
+    
+    # Housekeeping
+    _clean_header_cache()
     
     # Go to the file header
     try:
@@ -216,6 +218,9 @@ def get_first_channel(filehandle, frequency=False):
     buffer dump file.  If the `frequency` keyword is True the returned value is
     in Hz.
     """
+    
+    # Housekeeping
+    _clean_header_cache()
     
     # Go to the file header
     try:

--- a/lsl/reader/ovro.py
+++ b/lsl/reader/ovro.py
@@ -118,6 +118,20 @@ class Frame(FrameBase):
 
 _HEADER_CACHE = {}
 
+def _clean_header_cache():
+    """
+    Internal function to deal with housekeeping on the header cache.
+    """
+    
+    to_remove = []
+    for key in _HEADER_CACHE.keys():
+        if key.closed:
+            to_remove.append(key)
+            
+    for key in to_remove:
+        del _HEADER_CACHE[key]
+
+
 def read_frame(filehandle, verbose=False):
     """
     Function to read in a single OVRO-LWA triggered voltage buffer dump file

--- a/lsl/reader/ovro.py
+++ b/lsl/reader/ovro.py
@@ -1,0 +1,142 @@
+"""
+Python module to reading in data from OVRO-LWA trigger voltage buffer dump files.
+This module defines the following classes for storing the voltage buffer data
+found in a file:
+
+Frame
+  object that contains all data associated with a particular TBF frame.  The 
+  primary consituents of each frame are:
+    * FrameHeader - the TBF frame header object and
+    * FramePayload   - the TBF frame data object.  
+Combined, these two objects contain all of the information found in the 
+original TBF frame.
+
+The functions defined in this module fall into two class:
+  1. convert a frame in a file to a Frame object and
+  2. describe the format of the data in the file.
+
+For reading in data, use the read_frame function.  It takes a python file-
+handle as an input and returns a fully-filled Frame object.
+"""
+
+# Python2 compatibility
+from __future__ import print_function, division, absolute_import
+import sys
+if sys.version_info < (3,):
+    range = xrange
+    
+import json
+import numpy
+import struct
+
+from lsl.common import adp as adp_common
+from lsl.reader.base import *
+from lsl.reader._gofast import read_ovro
+from lsl.reader._gofast import SyncError as gSyncError
+from lsl.reader._gofast import EOFError as gEOFError
+from lsl.reader.errors import SyncError, EOFError
+from lsl.reader.utils import FilePositionSaver
+
+from lsl.misc import telemetry
+telemetry.track_module()
+
+
+__version__ = '0.1'
+
+class FrameHeader(FrameHeaderBase):
+    _header_attrs = ['time_tag', 'seq0', 'first_chan', 'nchan']
+    
+    def __init__(self, timetag=None, seq0=None, first_chan=None, nchan=None):
+        self.timetag = time_tag
+        self.seq0 = seq0
+        self.first_chan = first_chan
+        self.nchan = nchan
+        FrameHeaderBase.__init__(self)
+        
+    @property
+    def time(self):
+        """
+        Function to convert the time tag from samples since the UNIX epoch
+        (UTC 1970-01-01 00:00:00) to seconds since the UNIX epoch as a 
+        `lsl.reader.base.FrameTimestamp` instance.
+        """
+        
+        return FrameTimestamp.from_dp_timetag(self.timetag)
+    @property
+    def channel_freqs(self):
+        """
+        Return a numpy.float32 array for the center frequencies, in Hz, of
+        each channel in the data.
+        """
+        
+        return (numpy.arange(self.nchan, dtype=numpy.float32)+self.first_chan) * 196e6 / 8192
+
+
+class FramePayload(FramePayloadBase):
+    """
+    Class that stores the information found in the data section of a OVRO-LWA
+    triggered voltage buffer dump file.
+    """
+    
+    _payload_attrs = []
+    
+    def __init__(self, timetag=None, fDomain=None):
+        FramePayloadBase.__init__(self, fDomain)
+
+
+class Frame(FrameBase):
+    """
+    Class that stores the information contained within a OVRO-LWA triggered
+    voltage buffer dump file.  It's properties are FrameHeader and FramePayload
+    objects.
+    """
+    
+    _header_class = FrameHeader
+    _payload_class = FramePayload
+    
+    
+    @property
+    def channel_freqs(self):
+        """
+        Convenience wrapper for the Frame.FrameHeader.channel_freqs property.
+        """
+        
+        return self.header.channel_freqs
+        
+    @property
+    def time(self):
+        """
+        Convenience wrapper for the Frame.FramePayload.time property.
+        """
+        
+        return self.header.time
+
+
+def read_frame(filehandle, verbose=False):
+    """
+    Function to read in a single OVRO-LWA triggered voltage buffer dump file
+    (header+data) and store the contents as a Frame object.
+    """
+    
+    try:
+        hsize, hblock_size = struct.unpack('<II', filehandle.read(8))
+        header = json.loads(filehandle.read(hsize))
+        nchan = header['nchan']
+        nstand = header['nstand']
+        npol = header['npol']
+        filehandle.seek(hblock_size))
+        ntime = os.path.getsize(filehandle.name) - filehandle.tell()
+        ntime //= (nchan*nstand*npol*1) 
+        
+        data = read_ovro(filehandle, ntime, nchan, nstand, npol)
+        
+        newFrame = Frame()
+        newFrame.header.timetag = header['time_tag']
+        newFrame.header.seq0 = header['seq0']
+        newFrame.header.first_chan = header['chan0']
+        newFrame.header.nchan = nchan
+        newFrame.payload._data = data
+    except (OSError, gEOFError):
+        raise EOFError
+        
+    return newFrame

--- a/lsl/reader/ovro.py
+++ b/lsl/reader/ovro.py
@@ -32,7 +32,7 @@ import struct
 
 from lsl.common import adp as adp_common
 from lsl.reader.base import *
-from lsl.reader._gofast import read_ovro
+from lsl.reader._gofast import read_ovro_spec
 from lsl.reader._gofast import SyncError as gSyncError
 from lsl.reader._gofast import EOFError as gEOFError
 from lsl.reader.errors import SyncError, EOFError
@@ -144,7 +144,7 @@ def read_frame(filehandle, verbose=False):
     
     try:
         delta_timetag = (filehandle.tell() - hblock_size) // (nchan*nstand*npol*1)
-        data = read_ovro(filehandle, nchan, nstand, npol)
+        data = read_ovro_spec(filehandle, nchan, nstand, npol)
         
         newFrame = Frame()
         newFrame.header.timetag = header['time_tag'] + delta_timetag

--- a/lsl/reader/readers.h
+++ b/lsl/reader/readers.h
@@ -113,7 +113,7 @@ extern PyObject *read_cor(PyObject*, PyObject*);
 extern char read_cor_doc[];
 
 // ovro.c
-extern PyObject *read_ovro(PyObject*, PyObject*);
-extern char read_ovro_doc[];
+extern PyObject *read_ovro_spec(PyObject*, PyObject*);
+extern char read_ovro_spec_doc[];
 
 #endif	// __READERS_H

--- a/lsl/reader/readers.h
+++ b/lsl/reader/readers.h
@@ -65,6 +65,7 @@ extern short int tbw4LUT[256][2];
 extern float tbnLUT[256];
 extern float drxLUT[256][2];
 extern float tbfLUT[256][2];
+extern float ovroLUT[256][2];
 extern float drx8LUT[256];
 
 
@@ -110,5 +111,9 @@ extern char read_tbf_doc[];
 // cor.c
 extern PyObject *read_cor(PyObject*, PyObject*);
 extern char read_cor_doc[];
+
+// ovro.c
+extern PyObject *read_ovro(PyObject*, PyObject*);
+extern char read_ovro_doc[];
 
 #endif	// __READERS_H

--- a/scripts/ovroSpectra.py
+++ b/scripts/ovroSpectra.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+"""
+Given a OVRO-LWA triggered voltage buffer dump file, plot the time averaged
+spectra for each digitizer input.
+"""
+
+# Python2 compatibility
+from __future__ import print_function, division, absolute_import
+import sys
+if sys.version_info < (3,):
+    range = xrange
+    
+import os
+import sys
+import math
+import numpy
+import argparse
+
+from lsl.reader import ovro, errors
+from lsl.common import stations, metabundleADP
+from lsl.misc import parser as aph
+
+from matplotlib import pyplot as plt
+
+from lsl.misc import telemetry
+telemetry.track_script()
+
+
+def _best_freq_units(freq):
+    """Given a numpy array of frequencies in Hz, return a new array with the
+    frequencies in the best units possible (kHz, MHz, etc.)."""
+    
+    # Figure out how large the data are
+    scale = int(math.log10(freq.max()))
+    if scale >= 9:
+        divis = 1e9
+        units = 'GHz'
+    elif scale >= 6:
+        divis = 1e6
+        units = 'MHz'
+    elif scale >= 3:
+        divis = 1e3
+        units = 'kHz'
+    else:
+        divis = 1
+        units = 'Hz'
+        
+    # Convert the frequency
+    newFreq = freq / divis
+    
+    # Return units and freq
+    return (newFreq, units)
+
+
+def main(args):
+    fh = open(args.filename, 'rb')
+    
+    # Read in the frame and pull out the start time as well as the number of stand/pols.
+    frame = ovro.read_frame(fh)
+    beginDate = frame.time
+    antpols = frame.payload.data.shape[-2]*frame.payload.data.shape[-1]
+    
+    # Make a dummy list of antennas
+    antennas = list(range(antpols))
+    
+    # Figure out how many frames there are per observation and the number of
+    # channels that are in the file
+    nFrames = nFramesPerObs = 1
+    nchannels = frame.header.nchan
+    nSamples = frame.payload.data.shape[0]
+    
+    # Calculate the frequencies
+    freq = frame.channel_freqs
+    
+    # File summary
+    print("Filename: %s" % args.filename)
+    print("Date of First Frame: %s" % str(beginDate))
+    print("Frames per Observation: %i" % nFramesPerObs)
+    print("Channel Count: %i" % nchannels)
+    print("Frames: %i" % nFrames)
+    print("===")
+    
+    # Convert to spectra
+    spec = numpy.abs(frame.payload.data)**2
+    spec = spec.mean(axis=0)
+    
+    fh.close()
+    
+    # Reshape and transpose to get it in to a "normal" order
+    spec.shape = (spec.shape[0], spec.shape[1]*spec.shape[2])
+    spec = spec.T
+    
+    # Put the frequencies in the best units possible
+    freq, units = _best_freq_units(freq)
+    
+    # Deal with the `keep` options
+    if args.keep == 'all':
+        antpolsDisp = int(numpy.ceil(antpols/20))
+        js = [i for i in range(antpols)]
+    else:
+        antpolsDisp = int(numpy.ceil(len(args.keep)*2/20))
+        if antpolsDisp < 1:
+            antpolsDisp = 1
+            
+        js = []
+        for k in args.keep:
+            for i,ant in enumerate(antennas):
+                if ant == k:
+                    js.append(i)
+                    
+    nPlot = len(js)
+    if nPlot < 16:
+        if nPlot % 4 == 0 and nPlot != 4:
+            figsY = 4
+        else:
+            figsY = 2
+        figsX = int(numpy.ceil(1.0*nPlot/figsY))
+    else:
+        figsY = 4
+        figsX = 4
+    figsN = figsX*figsY
+    for i in range(antpolsDisp):
+        # Normal plotting
+        fig = plt.figure()
+        for k in range(i*figsN, i*figsN+figsN):
+            try:
+                j = js[k]
+                currSpectra = numpy.squeeze( numpy.log10(spec[j,:])*10.0 )
+            except IndexError:
+                break
+            ax = fig.add_subplot(figsX, figsY, (k%figsN)+1)
+            ax.plot(freq, currSpectra, label='Dig: %i' % (antennas[j]))
+            
+            ax.set_title('Dig: %i' % (antennas[j],))
+            ax.set_xlabel('Frequency [%s]' % units)
+            ax.set_ylabel('P.S.D. [dB/RBW]')
+            ax.set_ylim([-10, 30])
+            
+        # Save spectra image if requested
+        if args.output is not None:
+            base, ext = os.path.splitext(args.output)
+            outFigure = "%s-%02i%s" % (base, i+1, ext)
+            fig.savefig(outFigure)
+            
+        plt.draw()
+        
+    print("RBW: %.4f %s" % ((freq[1]-freq[0]), units))
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+            description='read in a OVRO-LWA triggered voltage buffer dump file and create a collection of time-averaged spectra', 
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+    parser.add_argument('filename', type=str, 
+                        help='filename to process')
+    parser.add_argument('-q', '--quiet', dest='verbose', action='store_false',
+                        help='run %(prog)s in silent mode')
+    parser.add_argument('-k', '--keep', type=aph.csv_int_list, default='all', 
+                        help='only display the following comma-seperated list of stands')
+    parser.add_argument('-o', '--output', type=str, 
+                        help='output file name for spectra image')
+    args = parser.parse_args()
+    main(args)
+    

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ coreExtraLibs = []
 
 # Create the list of extension modules.  We do this here so that we can turn 
 # off the DRSU direct module for non-linux system
-ExtensionModules = [Extension('reader._gofast', ['lsl/reader/gofast.c', 'lsl/reader/tbw.c', 'lsl/reader/tbn.c', 'lsl/reader/drx.c', 'lsl/reader/drspec.c', 'lsl/reader/vdif.c', 'lsl/reader/tbf.c', 'lsl/reader/cor.c'], include_dirs=[numpy.get_include()], extra_compile_args=['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION', '-funroll-loops']),
+ExtensionModules = [Extension('reader._gofast', ['lsl/reader/gofast.c', 'lsl/reader/tbw.c', 'lsl/reader/tbn.c', 'lsl/reader/drx.c', 'lsl/reader/drspec.c', 'lsl/reader/vdif.c', 'lsl/reader/tbf.c', 'lsl/reader/cor.c', 'lsl/reader/ovro.c'], include_dirs=[numpy.get_include()], extra_compile_args=['-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION', '-funroll-loops']),
             Extension('common._fir', ['lsl/common/fir.cpp'], include_dirs=[numpy.get_include()], libraries=['m'], extra_compile_args=coreExtraFlags, extra_link_args=coreExtraLibs),
             Extension('correlator._spec', ['lsl/correlator/spec.cpp'], include_dirs=[numpy.get_include()], libraries=['m'], extra_compile_args=coreExtraFlags, extra_link_args=coreExtraLibs), 
             Extension('correlator._stokes', ['lsl/correlator/stokes.cpp'], include_dirs=[numpy.get_include()], libraries=['m'], extra_compile_args=coreExtraFlags, extra_link_args=coreExtraLibs),


### PR DESCRIPTION
This PR adds support for loading triggered voltage buffer dumps from OVRO-LWA in a style that is similar to `lsl.reader.tbf`.