### PR TITLE
Update `Content-Length` discovery for newer Py3.

### DIFF
--- a/lsl/astro.py
+++ b/lsl/astro.py
@@ -3172,11 +3172,16 @@ def _parse_tai_file():
         
         print("Downloading %s" % url)
         lsFH = urlopen(url, timeout=DOWN_CONFIG.get('timeout'))
-        meta = lsFH.info()
+        remote_size = 1
         try:
+            remote_size = int(lsFH.headers["Content-Length"])
+        except AttributeError:
+            pass
+        try:
+            meta = lsFH.info()
             remote_size = int(meta.getheaders("Content-Length")[0])
         except AttributeError:
-            remote_size = 1
+            pass
         pbar = DownloadBar(max=remote_size)
         while True:
             new_data = lsFH.read(DOWN_CONFIG.get('block_size'))

--- a/lsl/misc/ionosphere.py
+++ b/lsl/misc/ionosphere.py
@@ -485,11 +485,16 @@ def _download_worker_standard(url, filename):
     print("Downloading %s" % url)
     try:
         tecFH = urlopen(url, timeout=DOWN_CONFIG.get('timeout'))
-        meta = tecFH.info()
+        remote_size = 1
         try:
+            remote_size = int(tecFH.headers["Content-Length"])
+        except AttributeError:
+            pass
+        try:
+            meta = tecFH.info()
             remote_size = int(meta.getheaders("Content-Length")[0])
         except AttributeError:
-            remote_size = 1
+            pass
         pbar = DownloadBar(max=remote_size)
         while True:
             new_data = tecFH.read(DOWN_CONFIG.get('block_size'))

--- a/scripts/updateLSLSSMIF.py
+++ b/scripts/updateLSLSSMIF.py
@@ -178,11 +178,16 @@ def main(args):
         try:
             print("Downloading %s" % urlToDownload)
             ah = urlopen(urlToDownload, timeout=LSL_CONFIG.get('download.timeout'))
-            meta = ah.info()
+            remote_size = 1
             try:
+                remote_size = int(ah.headers["Content-Length"])
+            except AttributeError:
+                pass
+            try:
+                meta = ah.info()
                 remote_size = int(meta.getheaders("Content-Length")[0])
             except AttributeError:
-                remote_size = 1
+                pass
             pbar = DownloadBar(max=remote_size)
             while True:
                 new_data = ah.read(LSL_CONFIG.get('download.block_size'))


### PR DESCRIPTION
This PR updates LSL to use the newer `headers` attribute to access the HTTP response headers from URL request.  Before `info()` was called to retrieve a metadata object and headers were accessed from that through `getheader()`.