### PR TITLE
Merge standard/PFB functions in `lsl.correlator`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.1.8
+ * Switched the PFB in lsl.correlator.fx to a Hamming window
+ * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' enables a 4-tap Hamming windowed PFB
+ * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' overrides the 'window' keyword
+
 2.1.7
  * Updated the LWA-SV SSMIF to 2022/11/15
  * Updated the LWA1 SSMIF to 2022/11/15

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2.1.8
+ * Updated the Hamming window coefficients
  * Switched the PFB in lsl.correlator.fx to a Hamming window
  * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' enables a 4-tap Hamming windowed PFB
  * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' overrides the 'window' keyword

--- a/lsl/correlator/blas.hpp
+++ b/lsl/correlator/blas.hpp
@@ -1,9 +1,8 @@
-#ifndef CORRELATOR_BLAS_H_INCLUDE_GUARD_
-#define CORRELATOR_BLAS_H_INCLUDE_GUARD_
+#pragma once
 
 #include <complex>
 
-#include "common.h"
+#include "common.hpp"
 
 /*
   Easy BLAS for C++
@@ -45,5 +44,3 @@ inline void blas_dotc_sub(const int N,
      *  cblas_zdotc_sub(N, X, incX, Y, incY, dotc);
      */
 }
-
-#endif // CORRELATOR_BLAS_H_INCLUDE_GUARD_

--- a/lsl/correlator/common.h
+++ b/lsl/correlator/common.h
@@ -72,12 +72,12 @@ inline float hanning(float x) {
 */
 
 inline double hamming(double x) {
-    return 0.53836 - 0.46164*cos(x);
+    return 0.543478261 - 0.456521739*cos(x);
     
 }
 
 inline float hamming(float x) {
-    return 0.53836 - 0.46164*cos(x);
+    return 0.543478261 - 0.456521739*cos(x);
 }
 
 

--- a/lsl/correlator/common.h
+++ b/lsl/correlator/common.h
@@ -72,12 +72,12 @@ inline float hanning(float x) {
 */
 
 inline double hamming(double x) {
-    return 0.543478261 - 0.456521739*cos(x);
+    return 0.54 - 0.46*cos(x);
     
 }
 
 inline float hamming(float x) {
-    return 0.543478261 - 0.456521739*cos(x);
+    return 0.54 - 0.46*cos(x);
 }
 
 

--- a/lsl/correlator/common.hpp
+++ b/lsl/correlator/common.hpp
@@ -1,5 +1,4 @@
-#ifndef CORRELATOR_COMMON_H_INCLUDE_GUARD_
-#define CORRELATOR_COMMON_H_INCLUDE_GUARD_
+#pragma once
 
 #include "Python.h"
 #include <cmath>
@@ -113,5 +112,3 @@ inline float abs2(Complex32 z) {
 inline double abs2(Complex64 z) {
     return z.real()*z.real() + z.imag()*z.imag();
 }
-
-#endif // CORRELATOR_COMMON_H_INCLUDE_GUARD_

--- a/lsl/correlator/common.hpp
+++ b/lsl/correlator/common.hpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdlib>
+#include <fftw3.h>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
 

--- a/lsl/correlator/common.hpp
+++ b/lsl/correlator/common.hpp
@@ -3,8 +3,26 @@
 #include "Python.h"
 #include <cmath>
 #include <complex>
+#include <cstdlib>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
+
+/*
+ 64-byte aligned memory allocator/deallocator
+*/
+
+inline void* aligned64_malloc(size_t size) {
+  void *ptr = NULL;
+  int err = posix_memalign(&ptr, 64, size);
+  if( err != 0 ) {
+    return NULL;
+  }
+  return ptr;
+}
+
+inline void aligned64_free(void* ptr) {
+  free(ptr);
+}
 
 
 /*

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -245,7 +245,7 @@ void compute_pfbengine_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -454,7 +454,7 @@ void compute_pfbengine_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -113,21 +113,21 @@ FFT Functions ("F-engines")
 
 
 template<typename InType, typename OutType>
-void compute_pfbengine_real(long nStand,
-                            long nSamps,
-                            long nFFT,
-                            int nChan,
-                            int nTap,
-                            int Overlap,
-                            int Clip,
-                            double SampleRate,
-                            InType const* data,
-                            double const* freq,
-                            long const* fifo,
-                            double const* frac,
-                            double const* window,
-                            OutType* fdomain,
-                            unsigned char* valid) {
+void compute_fengine_real(long nStand,
+                          long nSamps,
+                          long nFFT,
+                          int nChan,
+                          int nTap,
+                          int Overlap,
+                          int Clip,
+                          double SampleRate,
+                          InType const* data,
+                          double const* freq,
+                          long const* fifo,
+                          double const* frac,
+                          double const* window,
+                          OutType* fdomain,
+                          unsigned char* valid) {
     // Setup
     long ij, i, j, k, l;
     
@@ -222,21 +222,21 @@ void compute_pfbengine_real(long nStand,
 
 
 template<typename InType, typename OutType>
-void compute_pfbengine_complex(long nStand,
-                               long nSamps,
-                               long nFFT,
-                               int nChan,
-                               int nTap,
-                               int Overlap,
-                               int Clip,
-                               double SampleRate,
-                               InType const* data,
-                               double const* freq,
-                               long const* fifo,
-                               double const* frac,
-                               double const* window,
-                               OutType* fdomain,
-                               unsigned char* valid) {
+void compute_fengine_complex(long nStand,
+                             long nSamps,
+                             long nFFT,
+                             int nChan,
+                             int nTap,
+                             int Overlap,
+                             int Clip,
+                             double SampleRate,
+                             InType const* data,
+                             double const* freq,
+                             long const* fifo,
+                             double const* frac,
+                             double const* window,
+                             OutType* fdomain,
+                             unsigned char* valid) {
     // Setup
     long ij, i, j, k, l;
     
@@ -441,21 +441,21 @@ static PyObject *FEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_FENGINE_REAL(IterType) \
-        compute_pfbengine_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, SampleRate, \
-                                         (IterType*) PyArray_DATA(data), \
-                                         (double*) PyArray_DATA(freq), \
-                                         (long*) fifo, (double*) frac, \
-                                         (double*) PyArray_SAFE_DATA(windowData), \
-                                         (Complex32*) PyArray_DATA(dataF), \
-                                         (unsigned char*) PyArray_DATA(validF))
+        compute_fengine_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, SampleRate, \
+                                       (IterType*) PyArray_DATA(data), \
+                                       (double*) PyArray_DATA(freq), \
+                                       (long*) fifo, (double*) frac, \
+                                       (double*) PyArray_SAFE_DATA(windowData), \
+                                       (Complex32*) PyArray_DATA(dataF), \
+                                       (unsigned char*) PyArray_DATA(validF))
 #define LAUNCH_FENGINE_COMPLEX(IterType) \
-        compute_pfbengine_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, SampleRate, \
-                                            (IterType*) PyArray_DATA(data), \
-                                            (double*) PyArray_DATA(freq), \
-                                            (long*) fifo, (double*) frac, \
-                                            (double*) PyArray_SAFE_DATA(windowData), \
-                                            (Complex32*) PyArray_DATA(dataF), \
-                                            (unsigned char*) PyArray_DATA(validF))
+        compute_fengine_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, SampleRate, \
+                                          (IterType*) PyArray_DATA(data), \
+                                          (double*) PyArray_DATA(freq), \
+                                          (long*) fifo, (double*) frac, \
+                                          (double*) PyArray_SAFE_DATA(windowData), \
+                                          (Complex32*) PyArray_DATA(dataF), \
+                                          (unsigned char*) PyArray_DATA(validF))
     
     switch( PyArray_TYPE(data) ){
         case( NPY_INT8       ): LAUNCH_FENGINE_REAL(int8_t);    break;
@@ -638,21 +638,21 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PFBENGINE_REAL(IterType) \
-        compute_pfbengine_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, SampleRate, \
-                                         (IterType*) PyArray_DATA(data), \
-                                         (double*) PyArray_DATA(freq), \
-                                         (long*) fifo, (double*) frac, \
-                                         pfb, \
-                                         (Complex32*) PyArray_DATA(dataF), \
-                                         (unsigned char*) PyArray_DATA(validF))
+        compute_fengine_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, SampleRate, \
+                                       (IterType*) PyArray_DATA(data), \
+                                       (double*) PyArray_DATA(freq), \
+                                       (long*) fifo, (double*) frac, \
+                                       pfb, \
+                                       (Complex32*) PyArray_DATA(dataF), \
+                                       (unsigned char*) PyArray_DATA(validF))
 #define LAUNCH_PFBENGINE_COMPLEX(IterType) \
-        compute_pfbengine_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, SampleRate, \
-                                            (IterType*) PyArray_DATA(data), \
-                                            (double*) PyArray_DATA(freq), \
-                                            (long*) fifo, (double*) frac, \
-                                            pfb, \
-                                            (Complex32*) PyArray_DATA(dataF), \
-                                            (unsigned char*) PyArray_DATA(validF))
+        compute_fengine_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, SampleRate, \
+                                          (IterType*) PyArray_DATA(data), \
+                                          (double*) PyArray_DATA(freq), \
+                                          (long*) fifo, (double*) frac, \
+                                          pfb, \
+                                          (Complex32*) PyArray_DATA(dataF), \
+                                          (unsigned char*) PyArray_DATA(validF))
     
     switch( PyArray_TYPE(data) ){
         case( NPY_INT8       ): LAUNCH_PFBENGINE_REAL(int8_t);    break;

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -527,7 +527,7 @@ Outputs:\n\
 
 static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     PyObject *signals, *freqs, *delays, *window=Py_None, *signalsF;
-    PyArrayObject *data=NULL, *freq=NULL, *delay=NULL, *dataF=NULL, *validF=NULL, *windowData=NULL;
+    PyArrayObject *data=NULL, *freq=NULL, *delay=NULL, *dataF=NULL, *validF=NULL;
     int isReal;
     int nChan = 64;
     int nTap = PFB_NTAP;
@@ -678,7 +678,6 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     Py_XDECREF(data);
     Py_XDECREF(freq);
     Py_XDECREF(delay);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
     Py_XDECREF(validF);
     
@@ -691,7 +690,6 @@ fail:
     Py_XDECREF(data);
     Py_XDECREF(freq);
     Py_XDECREF(delay);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
     Py_XDECREF(validF);
     

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -153,7 +153,7 @@ void compute_fengine_real(long nStand,
     
     // Pre-compute the phase rotation and scaling factor
     OutType* rot;
-    rot = (OutType*) malloc(sizeof(OutType) * nStand*nChan);
+    rot = (OutType*) aligned64_malloc(sizeof(OutType) * nStand*nChan);
     compute_phase_rotator(nStand, nChan, SampleRate, 0, 2*nChan, freq, fifo, frac, rot);
     
     #ifdef _OPENMP
@@ -210,7 +210,7 @@ void compute_fengine_real(long nStand,
         fftwf_free(in);
         fftwf_free(out);
     }
-    free(rot);
+    aligned64_free(rot);
     
     fftwf_destroy_plan(p);
     fftwf_free(inP);
@@ -260,7 +260,7 @@ void compute_fengine_complex(long nStand,
     
     // Pre-compute the phase rotation and scaling factor
     OutType* rot;
-    rot = (OutType*) malloc(sizeof(OutType) * nStand*nChan);
+    rot = (OutType*) aligned64_malloc(sizeof(OutType) * nStand*nChan);
     compute_phase_rotator(nStand, nChan, SampleRate, nChan/2, nChan, freq, fifo, frac, rot);
     
     #ifdef _OPENMP
@@ -320,7 +320,7 @@ void compute_fengine_complex(long nStand,
         
         fftwf_free(in);
     }
-    free(rot);
+    aligned64_free(rot);
     
     fftwf_destroy_plan(p);
     fftwf_free(inP);
@@ -405,8 +405,8 @@ static PyObject *FEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     // Compute the integer sample offset and the fractional sample delay for each stand
     long *fifo, fifoMax;
     double *frac;
-    fifo = (long *) malloc(nStand*sizeof(long));
-    frac = (double *) malloc(nStand*nChan*sizeof(double));
+    fifo = (long *) aligned64_malloc(nStand*sizeof(long));
+    frac = (double *) aligned64_malloc(nStand*nChan*sizeof(double));
     if( fifo == NULL || frac == NULL ) {
         PyErr_Format(PyExc_MemoryError, "Cannot create fifo/fractional delay arrays");
         goto fail;
@@ -423,8 +423,8 @@ static PyObject *FEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     dataF = (PyArrayObject*) PyArray_ZEROS(3, dims, NPY_COMPLEX64, 0);
     if(dataF == NULL) {
         PyErr_Format(PyExc_MemoryError, "Cannot create output array");
-        free(fifo);
-        free(frac);
+        aligned64_free(fifo);
+        aligned64_free(frac);
         goto fail;
     }
     
@@ -435,8 +435,8 @@ static PyObject *FEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     validF = (PyArrayObject*) PyArray_ZEROS(2, dimsV, NPY_UINT8, 0);
     if(validF == NULL) {
         PyErr_Format(PyExc_MemoryError, "Cannot create valid index array");
-        free(fifo);
-        free(frac);
+        aligned64_free(fifo);
+        aligned64_free(frac);
         goto fail;
     }
     
@@ -472,8 +472,8 @@ static PyObject *FEngine(PyObject *self, PyObject *args, PyObject *kwds) {
 #undef LAUNCH_FENGINE_REAL
 #undef LAUNCH_FENGINE_COMPLEX
     
-    free(frac);
-    free(fifo);
+    aligned64_free(frac);
+    aligned64_free(fifo);
     
     signalsF = Py_BuildValue("(OO)", PyArray_Return(dataF), PyArray_Return(validF));
     
@@ -593,7 +593,7 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     isReal = 1 - PyArray_ISCOMPLEX(data);
     
     // Calculate the windowing function for the PFB
-    pfb = (double*) malloc(sizeof(double) * (1+isReal)*nChan*nTap);
+    pfb = (double*) aligned64_malloc(sizeof(double) * (1+isReal)*nChan*nTap);
     for(int i=0; i<(1+isReal)*nChan*nTap; i++) {
         *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
         *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
@@ -602,8 +602,8 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     // Compute the integer sample offset and the fractional sample delay for each stand
     long *fifo, fifoMax;
     double *frac;
-    fifo = (long *) malloc(nStand*sizeof(long));
-    frac = (double *) malloc(nStand*nChan*sizeof(double));
+    fifo = (long *) aligned64_malloc(nStand*sizeof(long));
+    frac = (double *) aligned64_malloc(nStand*nChan*sizeof(double));
     if( fifo == NULL || frac == NULL ) {
         PyErr_Format(PyExc_MemoryError, "Cannot create fifo/fractional delay arrays");
         goto fail;
@@ -620,8 +620,8 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     dataF = (PyArrayObject*) PyArray_ZEROS(3, dims, NPY_COMPLEX64, 0);
     if(dataF == NULL) {
         PyErr_Format(PyExc_MemoryError, "Cannot create output array");
-        free(fifo);
-        free(frac);
+        aligned64_free(fifo);
+        aligned64_free(frac);
         goto fail;
     }
     
@@ -632,8 +632,8 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     validF = (PyArrayObject*) PyArray_ZEROS(2, dimsV, NPY_UINT8, 0);
     if(validF == NULL) {
         PyErr_Format(PyExc_MemoryError, "Cannot create valid index array");
-        free(fifo);
-        free(frac);
+        aligned64_free(fifo);
+        aligned64_free(frac);
         goto fail;
     }
     
@@ -669,9 +669,9 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
 #undef LAUNCH_PFBENGINE_REAL
 #undef LAUNCH_PFBENGINE_COMPLEX
     
-    free(frac);
-    free(fifo);
-    free(pfb);
+    aligned64_free(frac);
+    aligned64_free(fifo);
+    aligned64_free(pfb);
     
     signalsF = Py_BuildValue("(OO)", PyArray_Return(dataF), PyArray_Return(validF));
     
@@ -685,7 +685,7 @@ static PyObject *PFBEngine(PyObject *self, PyObject *args, PyObject *kwds) {
     
 fail:
     if( pfb != NULL ) {
-        free(pfb);
+        aligned64_free(pfb);
     }
     Py_XDECREF(data);
     Py_XDECREF(freq);

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -245,7 +245,7 @@ void compute_pfbengine_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -454,7 +454,7 @@ void compute_pfbengine_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -16,8 +16,8 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
-#include "common.h"
-#include "blas.h"
+#include "common.hpp"
+#include "blas.hpp"
 
 
 /*

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -149,7 +149,7 @@ void compute_fengine_real(long nStand,
     long secStart;
     
     // Time-domain blanking control
-    double cleanFactor;
+    typename OutType::value_type cleanFactor;
     
     // Pre-compute the phase rotation and scaling factor
     OutType* rot;
@@ -206,7 +206,7 @@ void compute_fengine_real(long nStand,
             }
             
             for(k=0; k<nChan; k++) {
-                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = (float) cleanFactor * out[k];
+                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = cleanFactor * out[k];
                 *(fdomain + nChan*nFFT*i + nFFT*k + j) *= *(rot + nChan*i + k);
             }
             
@@ -262,7 +262,7 @@ void compute_fengine_complex(long nStand,
     long secStart;
     
     // Time-domain blanking control
-    double cleanFactor;
+    typename OutType::value_type cleanFactor;
     
     // Pre-compute the phase rotation and scaling factor
     OutType* rot;
@@ -313,11 +313,11 @@ void compute_fengine_complex(long nStand,
             }
             
             for(k=0; k<nChan/2; k++) {
-                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = (float) cleanFactor * in[k+nChan/2+nChan%2];
+                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = cleanFactor * in[k+nChan/2+nChan%2];
                 *(fdomain + nChan*nFFT*i + nFFT*k + j) *= *(rot + nChan*i + k);
             }
             for(k=nChan/2; k<nChan; k++) {
-                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = (float) cleanFactor * in[k-nChan/2];
+                *(fdomain + nChan*nFFT*i + nFFT*k + j)  = cleanFactor * in[k-nChan/2];
                 *(fdomain + nChan*nFFT*i + nFFT*k + j) *= *(rot + nChan*i + k);
             }
             

--- a/lsl/correlator/core.cpp
+++ b/lsl/correlator/core.cpp
@@ -173,19 +173,25 @@ void compute_fengine_real(long nStand,
             cleanFactor = 1.0;
             secStart = *(fifo + i) + nSamps*i + 2*nChan*j/Overlap;
             
-            for(k=0; k<2*nChan*nTap; k++) {
+            for(k=0; k<2*nChan*nTap; k+=2) {
                 if( secStart - 2*nChan*(nTap-1) + k < nSamps*i ) {
                     in[k] = 0.0;
                 } else {
                     in[k] = (float) *(data + secStart - 2*nChan*(nTap-1) + k);
                 }
+                if( secStart - 2*nChan*(nTap-1) + k + 1 < nSamps*i ) {
+                    in[k+1] = 0.0;
+                } else {
+                    in[k+1] = (float) *(data + secStart - 2*nChan*(nTap-1) + k + 1);
+                }
                 
-                if( Clip && fabs(in[k]) >= Clip ) {
+                if( Clip && (fabs(in[k]) >= Clip || abs(in[k+1]) >= Clip) ) {
                     cleanFactor = 0.0;
                 }
                 
                 if( window != NULL ) {
                     in[k] *= *(window + k);
+                    in[k+1] *= *(window + k + 1);
                 }
             }
             

--- a/lsl/correlator/fx.py
+++ b/lsl/correlator/fx.py
@@ -88,7 +88,8 @@ def SpecMaster(signals, LFFT=64, window=null_window, pfb=False, verbose=False, s
         SampleAverage keyword that calcSpectra does.
         
     .. versionchanged:: 1.2.5
-        Added the 'pfb' keyword.
+        Added the 'pfb' keyword to enable a 4-tap Hamming windowed PFB.  Enabling
+        this overrides the 'window' keyword.
     """
     
     # Figure out if we are working with complex (I/Q) data or only real.  This
@@ -137,7 +138,8 @@ def StokesMaster(signals, antennas, LFFT=64, window=null_window, pfb=False, verb
     dimensions Stokes parameter (0=I, 1=Q, 2=U, 3=V) by stand by channel).
     
     .. versionchanged:: 1.2.5
-        Added the 'pfb' keyword.
+        Added the 'pfb' keyword to enable a 4-tap Hamming windowed PFB.  Enabling
+        this overrides the 'window' keyword.
     """
     
     # Figure out if we are working with complex (I/Q) data or only real.  This
@@ -207,7 +209,8 @@ def FXMaster(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
          * a two-element tuple of azimuth, elevation in degrees.
          
     .. versionchanged:: 1.2.5
-        Added the 'pfb' keyword.
+        Added the 'pfb' keyword to enable a 4-tap Hamming windowed PFB.  Enabling
+        this overrides the 'window' keyword.
         
     .. versionchanged:: 2.0.1
         Added support for phase_center to be an astropy.coordinates.AltAz instance
@@ -360,7 +363,8 @@ def FXStokes(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
          * a two-element tuple of azimuth, elevation in degrees.
          
     .. versionchanged:: 1.2.5
-        Added the 'pfb' keyword.
+        Added the 'pfb' keyword to enable a 4-tap Hamming windowed PFB.  Enabling
+        this overrides the 'window' keyword.
     """
     
     # Since we want to compute Stokes parameters, we need both pols

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -151,7 +151,7 @@ void compute_pfb_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -346,7 +346,7 @@ void compute_pfb_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -357,8 +357,8 @@ Outputs:\n\
 
 
 static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
-    PyObject *signals, *signalsF, *window=Py_None, *arglist, *windowValue;
-    PyArrayObject *data=NULL, *dataF=NULL, *windowData=NULL;
+    PyObject *signals, *signalsF, *window=Py_None;
+    PyArrayObject *data=NULL, *dataF=NULL;
     int isReal;
     int nChan = 64;
     int nTap = PFB_NTAP;
@@ -445,7 +445,6 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     signalsF = Py_BuildValue("O", PyArray_Return(dataF));
     
     Py_XDECREF(data);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
 
     return signalsF;
@@ -455,7 +454,6 @@ fail:
         free(pfb);
     }
     Py_XDECREF(data);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
     
     return NULL;

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -16,8 +16,8 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
-#include "common.h"
-#include "blas.h"
+#include "common.hpp"
+#include "blas.hpp"
 
 /*
   Holder for window function callback

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -170,7 +170,7 @@ void compute_spec_complex(long nStand,
     #endif
     {
         in = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
-        temp2 = (double*) malloc(sizeof(double) * (nChan/2+nChan%2));
+        temp2 = (double*) aligned64_malloc(sizeof(double) * (nChan/2+nChan%2));
         
         #ifdef _OPENMP
             #pragma omp for schedule(OMP_SCHEDULER)
@@ -226,7 +226,7 @@ void compute_spec_complex(long nStand,
         }
         
         fftwf_free(in);
-        free(temp2);
+        aligned64_free(temp2);
     }
     fftwf_destroy_plan(p);
     fftwf_free(inP);
@@ -397,7 +397,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     isReal = 1 - PyArray_ISCOMPLEX(data);
     
     // Calculate the windowing function for the PFB
-    pfb = (double*) malloc(sizeof(double) * (1+isReal)*nChan*nTap);
+    pfb = (double*) aligned64_malloc(sizeof(double) * (1+isReal)*nChan*nTap);
     for(int i=0; i<(1+isReal)*nChan*nTap; i++) {
         *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
         *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
@@ -440,7 +440,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
 #undef LAUNCH_PFB_REAL
 #undef LAUNCH_PFB_COMPLEX
     
-    free(pfb);
+    aligned64_free(pfb);
     
     signalsF = Py_BuildValue("O", PyArray_Return(dataF));
     
@@ -451,7 +451,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     
 fail:
     if( pfb != NULL ) {
-        free(pfb);
+        aligned64_free(pfb);
     }
     Py_XDECREF(data);
     Py_XDECREF(dataF);

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -84,19 +84,25 @@ void compute_spec_real(long nStand,
                 cleanFactor = 1.0;
                 secStart = nSamps * i + 2*nChan*j/Overlap;
                 
-                for(k=0; k<2*nChan*nTap; k++) {
+                for(k=0; k<2*nChan*nTap; k+=2) {
                     if( secStart - 2*nChan*(nTap-1) + k < nSamps*i ) {
                         in[k] = 0.0;
                     } else {
                         in[k] = (float) *(data + secStart - 2*nChan*(nTap-1) + k);
                     }
+                    if( secStart - 2*nChan*(nTap-1) + k + 1 < nSamps*i ) {
+                        in[k+1] = 0.0;
+                    } else {
+                        in[k+1] = (float) *(data + secStart - 2*nChan*(nTap-1) + k + 1);
+                    }
                     
-                    if( Clip && fabs(in[k]) >= Clip ) {
+                    if( Clip && (fabs(in[k]) >= Clip || fabs(in[k+1]) >= Clip) ) {
                         cleanFactor = 0.0;
                     }
                     
                     if( window != NULL ) {
                       in[k] *= *(window + k);
+                      in[k+1] *= *(window + k + 1);
                     }
                 }
                 

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -211,7 +211,6 @@ void compute_pfb_real(long nStand,
         fftwf_free(in);
         fftwf_free(out);
     }
-    free(pfb);
     fftwf_destroy_plan(p);
     fftwf_free(inP);
     fftwf_free(outP);
@@ -407,7 +406,6 @@ void compute_pfb_complex(long nStand,
         fftwf_free(in);
         free(temp2);
     }
-    free(pfb);
     fftwf_destroy_plan(p);
     fftwf_free(inP);
     
@@ -577,7 +575,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     // Calculate the windowing function for the PFB
     double *pfb;
     pfb = (double*) malloc(sizeof(float) * nChan*nTap);
-    for(i=0; i<nChan*nTap; i++) {
+    for(int i=0; i<nChan*nTap; i++) {
         *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
         *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
     }
@@ -590,6 +588,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     dataF = (PyArrayObject*) PyArray_ZEROS(2, dims, NPY_DOUBLE, 0);
     if(dataF == NULL) {
         PyErr_Format(PyExc_MemoryError, "Cannot create output array");
+        free(pfb);
         goto fail;
     }
     
@@ -618,6 +617,8 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
         
 #undef LAUNCH_PFB_REAL
 #undef LAUNCH_PFB_COMPLEX
+    
+    free(pfb);
     
     signalsF = Py_BuildValue("O", PyArray_Return(dataF));
     

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -576,7 +576,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     // Calculate the windowing function for the PFB
     double *pfb;
     pfb = (double*) malloc(sizeof(float) * nChan*nTap);
-    for(int i=0; i<nChan*nTap; i++) {
+    for(int i=0; i<(1+isReal)*nChan*nTap; i++) {
         *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
         *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
     }

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -151,7 +151,7 @@ void compute_pfb_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -346,7 +346,7 @@ void compute_pfb_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -373,7 +373,7 @@ void compute_pfb_complex(long nStand,
                     }
                     
                     if( window != NULL ) {
-                      in[k] *= *(pfb + k);
+                      in[k] *= *(window + k);
                     }
                 }
                 
@@ -539,6 +539,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     PyArrayObject *data=NULL, *dataF=NULL, *windowData=NULL;
     int isReal;
     int nChan = 64;
+    int nTap = 4;
     int Overlap = 1;
     int Clip = 0;
     
@@ -573,7 +574,6 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     isReal = 1 - PyArray_ISCOMPLEX(data);
     
     // Calculate the windowing function for the PFB
-    int nTap = 4;
     double *pfb;
     pfb = (double*) malloc(sizeof(float) * nChan*nTap);
     for(int i=0; i<nChan*nTap; i++) {
@@ -594,12 +594,12 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PFB_REAL(IterType) \
-        compute_pfb_real<IterType>(nStand, nSamps, nFFT, nChan, 4, Overlap, Clip, \
+        compute_pfb_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
                                    (IterType*) PyArray_DATA(data), \
                                    pfb, \
                                    (double*) PyArray_DATA(dataF))
 #define LAUNCH_PFB_COMPLEX(IterType) \
-        compute_pfb_complex<IterType>(nStand, nSamps, nFFT, nChan, 4, Overlap, Clip, \
+        compute_pfb_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
                                       (IterType*) PyArray_DATA(data), \
                                       pfb, \
                                       (double*) PyArray_DATA(dataF))

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -573,6 +573,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     isReal = 1 - PyArray_ISCOMPLEX(data);
     
     // Calculate the windowing function for the PFB
+    int nTap = 4;
     double *pfb;
     pfb = (double*) malloc(sizeof(float) * nChan*nTap);
     for(int i=0; i<nChan*nTap; i++) {

--- a/lsl/correlator/spec.cpp
+++ b/lsl/correlator/spec.cpp
@@ -33,16 +33,16 @@ static PyObject *windowFunc = NULL;
 
 
 template<typename InType, typename OutType>
-void compute_real(long nStand,
-                  long nSamps,
-                  long nFFT,
-                  int nChan,
-                  int nTap,
-                  int Overlap,
-                  int Clip,
-                  InType const* data,
-                  double const* window,
-                  OutType* psd) {
+void compute_spec_real(long nStand,
+                       long nSamps,
+                       long nFFT,
+                       int nChan,
+                       int nTap,
+                       int Overlap,
+                       int Clip,
+                       InType const* data,
+                       double const* window,
+                       OutType* psd) {
     // Setup
     long i, j, k, l;
     
@@ -133,16 +133,16 @@ void compute_real(long nStand,
 
 
 template<typename InType, typename OutType>
-void compute_complex(long nStand,
-                      long nSamps,
-                      long nFFT,
-                      int nChan,
-                      int nTap,
-                      int Overlap,
-                      int Clip,
-                      InType const* data,
-                      double const* window,
-                      OutType* psd) {
+void compute_spec_complex(long nStand,
+                          long nSamps,
+                          long nFFT,
+                          int nChan,
+                          int nTap,
+                          int Overlap,
+                          int Clip,
+                          InType const* data,
+                          double const* window,
+                          OutType* psd) {
     // Setup
     long i, j, k, l;
     
@@ -294,15 +294,15 @@ static PyObject *FPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PSD_REAL(IterType) \
-        compute_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
-                               (IterType*) PyArray_DATA(data), \
-                               (double*) PyArray_SAFE_DATA(windowData), \
-                               (double*) PyArray_DATA(dataF))
+        compute_spec_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                                    (IterType*) PyArray_DATA(data), \
+                                    (double*) PyArray_SAFE_DATA(windowData), \
+                                    (double*) PyArray_DATA(dataF))
 #define LAUNCH_PSD_COMPLEX(IterType) \
-        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
-                                  (IterType*) PyArray_DATA(data), \
-                                  (double*) PyArray_SAFE_DATA(windowData), \
-                                  (double*) PyArray_DATA(dataF))
+        compute_spec_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                                       (IterType*) PyArray_DATA(data), \
+                                       (double*) PyArray_SAFE_DATA(windowData), \
+                                       (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(data) ){
         case( NPY_INT8       ): LAUNCH_PSD_REAL(int8_t);    break;
@@ -415,15 +415,15 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PFB_REAL(IterType) \
-        compute_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
-                               (IterType*) PyArray_DATA(data), \
-                               pfb, \
-                               (double*) PyArray_DATA(dataF))
+        compute_spec_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                                    (IterType*) PyArray_DATA(data), \
+                                    pfb, \
+                                    (double*) PyArray_DATA(dataF))
 #define LAUNCH_PFB_COMPLEX(IterType) \
-        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
-                                  (IterType*) PyArray_DATA(data), \
-                                  pfb, \
-                                  (double*) PyArray_DATA(dataF))
+        compute_spec_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                                       (IterType*) PyArray_DATA(data), \
+                                       pfb, \
+                                       (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(data) ){
         case( NPY_INT8       ): LAUNCH_PFB_REAL(int8_t);    break;
@@ -452,7 +452,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     
 fail:
     if( pfb != NULL ) {
-      free(pfb);
+        free(pfb);
     }
     Py_XDECREF(data);
     Py_XDECREF(windowData);

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -33,17 +33,17 @@ static PyObject *windowFunc = NULL;
 */
 
 template<typename InType, typename OutType>
-void compute_real(long nStand,
-                  long nSamps,
-                  long nFFT,
-                  int nChan,
-                  int nTap,
-                  int Overlap,
-                  int Clip,
-                  InType const* dataX,
-                  InType const* dataY,
-                  double const* window,
-                  OutType* psd) {
+void compute_stokes_real(long nStand,
+                         long nSamps,
+                         long nFFT,
+                         int nChan,
+                         int nTap,
+                         int Overlap,
+                         int Clip,
+                         InType const* dataX,
+                         InType const* dataY,
+                         double const* window,
+                         OutType* psd) {
     // Setup
     long i, j, k, l;
     
@@ -161,17 +161,17 @@ void compute_real(long nStand,
 
 
 template<typename InType, typename OutType>
-void compute_complex(long nStand,
-                     long nSamps,
-                     long nFFT,
-                     int nChan,
-                     int nTap,
-                     int Overlap,
-                     int Clip,
-                     InType const* dataX,
-                     InType const* dataY,
-                     double const* window,
-                     OutType* psd) {
+void compute_stokes_complex(long nStand,
+                            long nSamps,
+                            long nFFT,
+                            int nChan,
+                            int nTap,
+                            int Overlap,
+                            int Clip,
+                            InType const* dataX,
+                            InType const* dataY,
+                            double const* window,
+                            OutType* psd) {
     // Setup
     long i, j, k, l;
     
@@ -368,17 +368,17 @@ static PyObject *FPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PSD_REAL(IterType) \
-        compute_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
-                               (IterType*) PyArray_DATA(dataX), \
-                               (IterType*) PyArray_DATA(dataY), \
-                               (double*) PyArray_SAFE_DATA(windowData), \
-                               (double*) PyArray_DATA(dataF))
+        compute_stokes_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                                      (IterType*) PyArray_DATA(dataX), \
+                                      (IterType*) PyArray_DATA(dataY), \
+                                      (double*) PyArray_SAFE_DATA(windowData), \
+                                      (double*) PyArray_DATA(dataF))
 #define LAUNCH_PSD_COMPLEX(IterType) \
-        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
-                                  (IterType*) PyArray_DATA(dataX), \
-                                  (IterType*) PyArray_DATA(dataY), \
-                                  (double*) PyArray_SAFE_DATA(windowData), \
-                                  (double*) PyArray_DATA(dataF))
+        compute_stokes_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                                         (IterType*) PyArray_DATA(dataX), \
+                                         (IterType*) PyArray_DATA(dataY), \
+                                         (double*) PyArray_SAFE_DATA(windowData), \
+                                         (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(dataX) ){
         case( NPY_INT8       ): LAUNCH_PSD_REAL(int8_t);    break;
@@ -513,17 +513,17 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PFB_REAL(IterType) \
-        compute_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
-                               (IterType*) PyArray_DATA(dataX), \
-                               (IterType*) PyArray_DATA(dataY), \
-                               pfb, \
-                               (double*) PyArray_DATA(dataF))
+        compute_stokes_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                                      (IterType*) PyArray_DATA(dataX), \
+                                      (IterType*) PyArray_DATA(dataY), \
+                                      pfb, \
+                                      (double*) PyArray_DATA(dataF))
 #define LAUNCH_PFB_COMPLEX(IterType) \
-        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
-                                  (IterType*) PyArray_DATA(dataX), \
-                                  (IterType*) PyArray_DATA(dataY), \
-                                  pfb, \
-                                  (double*) PyArray_DATA(dataF))
+        compute_stokes_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                                         (IterType*) PyArray_DATA(dataX), \
+                                         (IterType*) PyArray_DATA(dataY), \
+                                         pfb, \
+                                         (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(dataX) ){
         case( NPY_INT8       ): LAUNCH_PFB_REAL(int8_t);    break;

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -437,8 +437,8 @@ Outputs:\n\
 
 
 static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
-    PyObject *signalsX, *signalsY, *signalsF, *window=Py_None, *arglist, *windowValue;
-    PyArrayObject *dataX=NULL, *dataY=NULL, *dataF=NULL, *windowData=NULL;
+    PyObject *signalsX, *signalsY, *signalsF, *window=Py_None;
+    PyArrayObject *dataX=NULL, *dataY=NULL, *dataF=NULL;
     int isReal;
     int nChan = 64;
     int nTap = PFB_NTAP;
@@ -546,7 +546,6 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     
     Py_XDECREF(dataX);
     Py_XDECREF(dataY);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
     
     return signalsF;
@@ -557,7 +556,6 @@ fail:
     }
     Py_XDECREF(dataX);
     Py_XDECREF(dataY);
-    Py_XDECREF(windowData);
     Py_XDECREF(dataF);
     
     return NULL;

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -33,31 +33,33 @@ static PyObject *windowFunc = NULL;
 */
 
 template<typename InType, typename OutType>
-void compute_psd_real(long nStand,
-                      long nSamps,
-                      long nFFT,
-                      int nChan, 
-                      int Overlap, 
-                      int Clip, 
-                      InType const* dataX,
-                      InType const* dataY,
-                      double const* window,
-                      OutType* psd) {
+void compute_real(long nStand,
+                  long nSamps,
+                  long nFFT,
+                  int nChan,
+                  int nTap,
+                  int Overlap,
+                  int Clip,
+                  InType const* dataX,
+                  InType const* dataY,
+                  double const* window,
+                  OutType* psd) {
     // Setup
-    long i, j, k;
+    long i, j, k, l;
     
     Py_BEGIN_ALLOW_THREADS
     
     // Create the FFTW plan                          
     float *inP, *inX, *inY;                          
     Complex32 *outP, *outX, *outY;
-    inP = (float*) fftwf_malloc(sizeof(float) * 2*nChan);
-    outP = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1));
+    inP = (float*) fftwf_malloc(sizeof(float) * 2*nChan*nTap);
+    outP = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*nTap);
     fftwf_plan p;
-    p = fftwf_plan_dft_r2c_1d(2*nChan, \
-                              inP, \
-                              reinterpret_cast<fftwf_complex*>(outP), \
-                              FFTW_ESTIMATE);
+    int n[] = {2*nChan,};
+    p = fftwf_plan_many_dft_r2c(1, n, nTap, \
+                                inP, NULL, 1, 2*nChan, \
+                                reinterpret_cast<fftwf_complex*>(outP), NULL, 1, nChan+1, \
+                                FFTW_ESTIMATE);
     
     // Data indexing and access
     long secStart;
@@ -67,13 +69,13 @@ void compute_psd_real(long nStand,
     long nActFFT;
     
     #ifdef _OPENMP
-        #pragma omp parallel default(shared) private(inX, inY, outX, outY, i, j, k, secStart, cleanFactor, nActFFT)
+        #pragma omp parallel default(shared) private(inX, inY, outX, outY, i, j, k, l, secStart, cleanFactor, nActFFT)
     #endif
     {
-        inX = (float*) fftwf_malloc(sizeof(float) * 2*nChan);
-        inY = (float*) fftwf_malloc(sizeof(float) * 2*nChan);
-        outX = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1));
-        outY = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1));
+        inX = (float*) fftwf_malloc(sizeof(float) * 2*nChan*nTap);
+        inY = (float*) fftwf_malloc(sizeof(float) * 2*nChan*nTap);
+        outX = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*nTap);
+        outY = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*nTap);
         
         #ifdef _OPENMP
             #pragma omp for schedule(OMP_SCHEDULER)
@@ -85,9 +87,14 @@ void compute_psd_real(long nStand,
                 cleanFactor = 1.0;
                 secStart = nSamps * i + 2*nChan*j/Overlap;
                 
-                for(k=0; k<2*nChan; k++) {
-                    inX[k] = (float) *(dataX + secStart + k);
-                    inY[k] = (float) *(dataY + secStart + k);
+                for(k=0; k<2*nChan*nTap; k++) {
+                    if( secStart - 2*nChan*(nTap-1) + k < nSamps*i ) {
+                        inX[k] = 0.0;
+                        inY[k] = 0.0;
+                    } else {
+                        inX[k] = (float) *(dataX + secStart - 2*nChan*(nTap-1) + k);
+                        inY[k] = (float) *(dataY + secStart - 2*nChan*(nTap-1) + k);
+                    }
                     
                     if( Clip && ( fabs(inX[k]) >= Clip || fabs(inY[k]) >= Clip ) ) {
                         cleanFactor = 0.0;
@@ -106,133 +113,7 @@ void compute_psd_real(long nStand,
                                       inY, \
                                       reinterpret_cast<fftwf_complex*>(outY));
                 
-                for(k=0; k<nChan; k++) {
-                    // I
-                    *(psd + 0*nChan*nStand + nChan*i + k) += cleanFactor*abs2(outX[k]);
-                    *(psd + 0*nChan*nStand + nChan*i + k) += cleanFactor*abs2(outY[k]);
-                    
-                    // Q
-                    *(psd + 1*nChan*nStand + nChan*i + k) += cleanFactor*abs2(outX[k]);
-                    *(psd + 1*nChan*nStand + nChan*i + k) -= cleanFactor*abs2(outY[k]);
-                    
-                    // U
-                    *(psd + 2*nChan*nStand + nChan*i + k) += 2*cleanFactor*outX[k].real()*outY[k].real();
-                    *(psd + 2*nChan*nStand + nChan*i + k) += 2*cleanFactor*outX[k].imag()*outY[k].imag();
-                    
-                    // V
-                    *(psd + 3*nChan*nStand + nChan*i + k) +=2*cleanFactor*outX[k].imag()*outY[k].real();
-                    *(psd + 3*nChan*nStand + nChan*i + k) -=2*cleanFactor*outX[k].real()*outY[k].imag();
-                }
-                
-                nActFFT += (long) cleanFactor;
-            }
-            
-            // Scale FFTs
-            for(j=0; j<4; j++) {
-                blas_scal(nChan, 1.0/(2*nChan*nActFFT), (psd + j*nChan*nStand + nChan*i), 1);
-            }
-        }
-        
-        fftwf_free(inX);
-        fftwf_free(inY);
-        fftwf_free(outX);
-        fftwf_free(outY);
-    }
-    fftwf_destroy_plan(p);
-    fftwf_free(inP);
-    fftwf_free(outP);
-    
-    Py_END_ALLOW_THREADS
-}
-
-
-template<typename InType, typename OutType>
-void compute_pfb_real(long nStand,
-                      long nSamps,
-                      long nFFT,
-                      int nChan, 
-                      int Overlap, 
-                      int Clip, 
-                      InType const* dataX,
-                      InType const* dataY,
-                      double const* window,
-                      OutType* psd) {
-    // Setup
-    long i, j, k, l;
-    
-    Py_BEGIN_ALLOW_THREADS
-    
-    // Create the FFTW plan                          
-    float *inP, *inX, *inY;                          
-    Complex32 *outP, *outX, *outY;
-    inP = (float*) fftwf_malloc(sizeof(float) * 2*nChan*PFB_NTAP);
-    outP = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*PFB_NTAP);
-    fftwf_plan p;
-    int n[] = {2*nChan,};
-    p = fftwf_plan_many_dft_r2c(1, n, PFB_NTAP, \
-                                inP, NULL, 1, 2*nChan, \
-                                reinterpret_cast<fftwf_complex*>(outP), NULL, 1, nChan+1, \
-                                FFTW_ESTIMATE);
-    
-    // Filter bank
-    float *pfb;
-    pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
-    for(i=0; i<2*nChan*PFB_NTAP; i++) {
-        *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hamming(2*NPY_PI*i/(2*nChan*PFB_NTAP));
-    }
-    
-    // Data indexing and access
-    long secStart;
-    
-    // Time-domain blanking control
-    double cleanFactor;
-    long nActFFT;
-    
-    #ifdef _OPENMP
-        #pragma omp parallel default(shared) private(inX, inY, outX, outY, i, j, k, l, secStart, cleanFactor, nActFFT)
-    #endif
-    {
-        inX = (float*) fftwf_malloc(sizeof(float) * 2*nChan*PFB_NTAP);
-        inY = (float*) fftwf_malloc(sizeof(float) * 2*nChan*PFB_NTAP);
-        outX = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*PFB_NTAP);
-        outY = (Complex32*) fftwf_malloc(sizeof(Complex32) * (nChan+1)*PFB_NTAP);
-        
-        #ifdef _OPENMP
-            #pragma omp for schedule(OMP_SCHEDULER)
-        #endif
-        for(i=0; i<nStand; i++) {
-            nActFFT = 0;
-            
-            for(j=0; j<nFFT; j++) {
-                cleanFactor = 1.0;
-                secStart = nSamps * i + 2*nChan*j/Overlap;
-                
-                for(k=0; k<2*nChan*PFB_NTAP; k++) {
-                    if( secStart - 2*nChan*(PFB_NTAP-1) + k < nSamps*i ) {
-                        inX[k] = 0.0;
-                        inY[k] = 0.0;
-                    } else {
-                        inX[k] = (float) *(dataX + secStart - 2*nChan*(PFB_NTAP-1) + k);
-                        inY[k] = (float) *(dataY + secStart - 2*nChan*(PFB_NTAP-1) + k);
-                    }
-                    
-                    if( Clip && ( fabs(inX[k]) >= Clip || fabs(inY[k]) >= Clip ) ) {
-                        cleanFactor = 0.0;
-                    }
-                    
-                    inX[k] *= *(pfb + k);
-                    inY[k] *= *(pfb + k);
-                }
-                
-                fftwf_execute_dft_r2c(p, \
-                                      inX, \
-                                      reinterpret_cast<fftwf_complex*>(outX));
-                fftwf_execute_dft_r2c(p, \
-                                      inY, \
-                                      reinterpret_cast<fftwf_complex*>(outY));
-                
-                for(l=1; l<PFB_NTAP; l++) {
+                for(l=1; l<nTap; l++) {
                     for(k=0; k<nChan; k++) {
                         outX[k] += outX[k+l*(nChan+1)];
                         outY[k] += outY[k+l*(nChan+1)];
@@ -271,7 +152,6 @@ void compute_pfb_real(long nStand,
         fftwf_free(outX);
         fftwf_free(outY);
     }
-    free(pfb);
     fftwf_destroy_plan(p);
     fftwf_free(inP);
     fftwf_free(outP);
@@ -281,29 +161,31 @@ void compute_pfb_real(long nStand,
 
 
 template<typename InType, typename OutType>
-void compute_psd_complex(long nStand,
-                         long nSamps,
-                         long nFFT,
-                         int nChan, 
-                         int Overlap, 
-                         int Clip, 
-                         InType const* dataX,
-                         InType const* dataY,
-                         double const* window,
-                         OutType* psd) {
+void compute_complex(long nStand,
+                     long nSamps,
+                     long nFFT,
+                     int nChan,
+                     int nTap,
+                     int Overlap,
+                     int Clip,
+                     InType const* dataX,
+                     InType const* dataY,
+                     double const* window,
+                     OutType* psd) {
     // Setup
-    long i, j, k;
+    long i, j, k, l;
     
     Py_BEGIN_ALLOW_THREADS
     
     // Create the FFTW plan
     Complex32 *inP, *inX, *inY;
-    inP = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan);
+    inP = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
     fftwf_plan p;
-    p = fftwf_plan_dft_1d(nChan, \
-                          reinterpret_cast<fftwf_complex*>(inP), \
-                          reinterpret_cast<fftwf_complex*>(inP), \
-                          FFTW_FORWARD, FFTW_ESTIMATE);
+    int n[] = {nChan,};
+    p = fftwf_plan_many_dft(1, n, nTap, \
+                            reinterpret_cast<fftwf_complex*>(inP), NULL, 1, nChan, \
+                            reinterpret_cast<fftwf_complex*>(inP), NULL, 1, nChan, \
+                            FFTW_FORWARD, FFTW_ESTIMATE);
     
     // Data indexing and access
     long secStart;
@@ -314,11 +196,11 @@ void compute_psd_complex(long nStand,
     long nActFFT;
     
     #ifdef _OPENMP
-        #pragma omp parallel default(shared) private(inX, inY, i, j, k, secStart, cleanFactor, nActFFT, temp2)
+        #pragma omp parallel default(shared) private(inX, inY, i, j, k, l, secStart, cleanFactor, nActFFT, temp2)
     #endif
     {
-        inX = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan);
-        inY = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan);
+        inX = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
+        inY = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
         temp2 = (double*) malloc(sizeof(double) * (nChan/2+nChan%2));
         
         #ifdef _OPENMP
@@ -331,11 +213,16 @@ void compute_psd_complex(long nStand,
                 cleanFactor = 1.0;
                 secStart = nSamps * i + nChan*j/Overlap;
                 
-                for(k=0; k<nChan; k++) {
-                    inX[k] = Complex32(*(dataX + 2*secStart + 2*k + 0), \
-                                       *(dataX + 2*secStart + 2*k + 1));
-                    inY[k] = Complex32(*(dataY + 2*secStart + 2*k + 0), \
-                                       *(dataY + 2*secStart + 2*k + 1));
+                for(k=0; k<nChan*nTap; k++) {
+                    if( secStart - nChan*(nTap-1) + k < nSamps*i ) {
+                        inX[k] = 0.0;
+                        inY[k] = 0.0;
+                    } else {
+                        inX[k] = Complex32(*(dataX + 2*secStart - 2*nChan*(nTap-1) + 2*k + 0), \
+                                           *(dataX + 2*secStart - 2*nChan*(nTap-1) + 2*k + 1));
+                        inY[k] = Complex32(*(dataY + 2*secStart - 2*nChan*(nTap-1) + 2*k + 0), \
+                                           *(dataY + 2*secStart - 2*nChan*(nTap-1) + 2*k + 1));
+                    }
                     
                     if( Clip && ( abs(inX[k]) >= Clip || abs(inY[k]) >= Clip ) ) {
                         cleanFactor = 0.0;
@@ -354,136 +241,7 @@ void compute_psd_complex(long nStand,
                                   reinterpret_cast<fftwf_complex*>(inY), \
                                   reinterpret_cast<fftwf_complex*>(inY));
                 
-                for(k=0; k<nChan; k++) {
-                    // I
-                    *(psd + 0*nChan*nStand + nChan*i + k) += cleanFactor*abs2(inX[k]);
-                    *(psd + 0*nChan*nStand + nChan*i + k) += cleanFactor*abs2(inY[k]);
-                    
-                    // Q
-                    *(psd + 1*nChan*nStand + nChan*i + k) += cleanFactor*abs2(inX[k]);
-                    *(psd + 1*nChan*nStand + nChan*i + k) -= cleanFactor*abs2(inY[k]);
-                    
-                    // U
-                    *(psd + 2*nChan*nStand + nChan*i + k) += 2*cleanFactor*inX[k].real()*inY[k].real();
-                    *(psd + 2*nChan*nStand + nChan*i + k) += 2*cleanFactor*inX[k].imag()*inY[k].imag();
-                    
-                    // V
-                    *(psd + 3*nChan*nStand + nChan*i + k) +=2*cleanFactor*inX[k].imag()*inY[k].real();
-                    *(psd + 3*nChan*nStand + nChan*i + k) -=2*cleanFactor*inX[k].real()*inY[k].imag();
-                }
-                
-                nActFFT += (long) cleanFactor;
-            }
-            
-            for(j=0; j<4; j++) {
-                // Shift FFTs
-                memcpy(temp2, (psd + j*nChan*nStand + nChan*i), sizeof(OutType)*(nChan/2+nChan%2));
-                memmove((psd + j*nChan*nStand + nChan*i), (psd + j*nChan*nStand + nChan*i)+nChan/2+nChan%2, sizeof(OutType)*nChan/2);
-                memcpy((psd + j*nChan*nStand + nChan*i)+nChan/2, temp2, sizeof(OutType)*(nChan/2+nChan%2));
-                
-                // Scale FFTs
-                blas_scal(nChan, 1.0/(nActFFT*nChan), (psd + j*nChan*nStand + nChan*i), 1);
-            }
-        }
-        
-        fftwf_free(inX);
-        fftwf_free(inY);
-        free(temp2);
-    }
-    fftwf_destroy_plan(p);
-    fftwf_free(inP);
-    
-    Py_END_ALLOW_THREADS
-}
-
-
-template<typename InType, typename OutType>
-void compute_pfb_complex(long nStand,
-                         long nSamps,
-                         long nFFT,
-                         int nChan, 
-                         int Overlap, 
-                         int Clip, 
-                         InType const* dataX,
-                         InType const* dataY,
-                         double const* window,
-                         OutType* psd) {
-    // Setup
-    long i, j, k, l;
-    
-    Py_BEGIN_ALLOW_THREADS
-    
-    // Create the FFTW plan
-    Complex32 *inP, *inX, *inY;
-    inP = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*PFB_NTAP);
-    fftwf_plan p;
-    int n[] = {nChan,};
-    p = fftwf_plan_many_dft(1, n, PFB_NTAP, \
-                            reinterpret_cast<fftwf_complex*>(inP), NULL, 1, nChan, \
-                            reinterpret_cast<fftwf_complex*>(inP), NULL, 1, nChan, \
-                            FFTW_FORWARD, FFTW_ESTIMATE);
-    
-    // Filter bank
-    float *pfb;
-    pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
-    for(i=0; i<nChan*PFB_NTAP; i++) {
-        *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hamming(2*NPY_PI*i/(nChan*PFB_NTAP));
-    }
-    
-    // Data indexing and access
-    long secStart;
-    double* temp2;
-    
-    // Time-domain blanking control
-    double cleanFactor;
-    long nActFFT;
-    
-    #ifdef _OPENMP
-        #pragma omp parallel default(shared) private(inX, inY, i, j, k, l, secStart, cleanFactor, nActFFT, temp2)
-    #endif
-    {
-        inX = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*PFB_NTAP);
-        inY = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*PFB_NTAP);
-        temp2 = (double*) malloc(sizeof(double) * (nChan/2+nChan%2));
-        
-        #ifdef _OPENMP
-            #pragma omp for schedule(OMP_SCHEDULER)
-        #endif
-        for(i=0; i<nStand; i++) {
-            nActFFT = 0;
-            
-            for(j=0; j<nFFT; j++) {
-                cleanFactor = 1.0;
-                secStart = nSamps * i + nChan*j/Overlap;
-                
-                for(k=0; k<nChan*PFB_NTAP; k++) {
-                    if( secStart - nChan*(PFB_NTAP-1) + k < nSamps*i ) {
-                        inX[k] = 0.0;
-                        inY[k] = 0.0;
-                    } else {
-                        inX[k] = Complex32(*(dataX + 2*secStart - 2*nChan*(PFB_NTAP-1) + 2*k + 0), \
-                                           *(dataX + 2*secStart - 2*nChan*(PFB_NTAP-1) + 2*k + 1));
-                        inY[k] = Complex32(*(dataY + 2*secStart - 2*nChan*(PFB_NTAP-1) + 2*k + 0), \
-                                           *(dataY + 2*secStart - 2*nChan*(PFB_NTAP-1) + 2*k + 1));
-                    }
-                    
-                    if( Clip && ( abs(inX[k]) >= Clip || abs(inY[k]) >= Clip ) ) {
-                        cleanFactor = 0.0;
-                    }
-                    
-                    inX[k] *= *(pfb + k);
-                    inY[k] *= *(pfb + k);
-                }
-                
-                fftwf_execute_dft(p, \
-                                  reinterpret_cast<fftwf_complex*>(inX), \
-                                  reinterpret_cast<fftwf_complex*>(inX));
-                fftwf_execute_dft(p,  \
-                                  reinterpret_cast<fftwf_complex*>(inY), \
-                                  reinterpret_cast<fftwf_complex*>(inY));
-                
-                for(l=1; l<PFB_NTAP; l++) {
+                for(l=1; l<nTap; l++) {
                     for(k=0; k<nChan; k++) {
                         inX[k] += inX[k+l*nChan];
                         inY[k] += inY[k+l*nChan];
@@ -526,7 +284,6 @@ void compute_pfb_complex(long nStand,
         fftwf_free(inY);
         free(temp2);
     }
-    free(pfb);
     fftwf_destroy_plan(p);
     fftwf_free(inP);
     
@@ -611,17 +368,17 @@ static PyObject *FPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PSD_REAL(IterType) \
-        compute_psd_real<IterType>(nStand, nSamps, nFFT, nChan, Overlap, Clip, \
-                                   (IterType*) PyArray_DATA(dataX), \
-                                   (IterType*) PyArray_DATA(dataY), \
-                                   (double*) PyArray_SAFE_DATA(windowData), \
-                                   (double*) PyArray_DATA(dataF))
+        compute_real<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                               (IterType*) PyArray_DATA(dataX), \
+                               (IterType*) PyArray_DATA(dataY), \
+                               (double*) PyArray_SAFE_DATA(windowData), \
+                               (double*) PyArray_DATA(dataF))
 #define LAUNCH_PSD_COMPLEX(IterType) \
-        compute_psd_complex<IterType>(nStand, nSamps, nFFT, nChan, Overlap, Clip, \
-                                      (IterType*) PyArray_DATA(dataX), \
-                                      (IterType*) PyArray_DATA(dataY), \
-                                      (double*) PyArray_SAFE_DATA(windowData), \
-                                      (double*) PyArray_DATA(dataF))
+        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, 1, Overlap, Clip, \
+                                  (IterType*) PyArray_DATA(dataX), \
+                                  (IterType*) PyArray_DATA(dataY), \
+                                  (double*) PyArray_SAFE_DATA(windowData), \
+                                  (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(dataX) ){
         case( NPY_INT8       ): LAUNCH_PSD_REAL(int8_t);    break;
@@ -684,10 +441,12 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     PyArrayObject *dataX=NULL, *dataY=NULL, *dataF=NULL, *windowData=NULL;
     int isReal;
     int nChan = 64;
+    int nTap = PFB_NTAP;
     int Overlap = 1;
     int Clip = 0;
     
     long nStand, nSamps, nFFT;
+    double *pfb = NULL;
     
     char const* kwlist[] = {"signalsX", "signalsY", "LFFT", "overlap", "clip_level", "window", NULL};
     if(!PyArg_ParseTupleAndKeywords(args, kwds, "OO|iiiO:set_callback", const_cast<char **>(kwlist), &signalsX, &signalsY, &nChan, &Overlap, &Clip, &window)) {
@@ -734,13 +493,11 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
         goto fail;
     }
     
-    // Calculate the windowing function
-    if( windowFunc != Py_None ) {
-        arglist = Py_BuildValue("(i)", (1+isReal)*nChan);
-        windowValue = PyObject_CallObject(windowFunc, arglist);
-        windowData = (PyArrayObject *) PyArray_ContiguousFromObject(windowValue, NPY_DOUBLE, 1, 1);
-        Py_DECREF(arglist);
-        Py_DECREF(windowValue);
+    // Calculate the windowing function for the PFB
+    pfb = (double*) malloc(sizeof(double) * (1+isReal)*nChan*nTap);
+    for(int i=0; i<(1+isReal)*nChan*nTap; i++) {
+        *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
+        *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
     }
     
     // Find out how large the output array needs to be and initialize it
@@ -756,17 +513,17 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
 #define LAUNCH_PFB_REAL(IterType) \
-        compute_pfb_real<IterType>(nStand, nSamps, nFFT, nChan, Overlap, Clip, \
-                                   (IterType*) PyArray_DATA(dataX), \
-                                   (IterType*) PyArray_DATA(dataY), \
-                                   (double*) PyArray_SAFE_DATA(windowData), \
-                                   (double*) PyArray_DATA(dataF))
+        compute_real<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                               (IterType*) PyArray_DATA(dataX), \
+                               (IterType*) PyArray_DATA(dataY), \
+                               pfb, \
+                               (double*) PyArray_DATA(dataF))
 #define LAUNCH_PFB_COMPLEX(IterType) \
-        compute_pfb_complex<IterType>(nStand, nSamps, nFFT, nChan, Overlap, Clip, \
-                                      (IterType*) PyArray_DATA(dataX), \
-                                      (IterType*) PyArray_DATA(dataY), \
-                                      (double*) PyArray_SAFE_DATA(windowData), \
-                                      (double*) PyArray_DATA(dataF))
+        compute_complex<IterType>(nStand, nSamps, nFFT, nChan, nTap, Overlap, Clip, \
+                                  (IterType*) PyArray_DATA(dataX), \
+                                  (IterType*) PyArray_DATA(dataY), \
+                                  pfb, \
+                                  (double*) PyArray_DATA(dataF))
     
     switch( PyArray_TYPE(dataX) ){
         case( NPY_INT8       ): LAUNCH_PFB_REAL(int8_t);    break;
@@ -783,6 +540,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
 #undef LAUNCH_PFB_REAL
 #undef LAUNCH_PFB_COMPLEX
     
+    free(pfb);
     
     signalsF = Py_BuildValue("O", PyArray_Return(dataF));
     
@@ -794,6 +552,9 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     return signalsF;
     
 fail:
+    if( pfb != NULL ) {
+        free(pfb);
+    }
     Py_XDECREF(dataX);
     Py_XDECREF(dataY);
     Py_XDECREF(windowData);

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -179,7 +179,7 @@ void compute_pfb_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -428,7 +428,7 @@ void compute_pfb_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
+        *(pfb + i) *= hamming(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -16,8 +16,8 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
-#include "common.h"
-#include "blas.h"
+#include "common.hpp"
+#include "blas.hpp"
 
 
 /*

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -201,7 +201,7 @@ void compute_stokes_complex(long nStand,
     {
         inX = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
         inY = (Complex32*) fftwf_malloc(sizeof(Complex32) * nChan*nTap);
-        temp2 = (double*) malloc(sizeof(double) * (nChan/2+nChan%2));
+        temp2 = (double*) aligned64_malloc(sizeof(double) * (nChan/2+nChan%2));
         
         #ifdef _OPENMP
             #pragma omp for schedule(OMP_SCHEDULER)
@@ -282,7 +282,7 @@ void compute_stokes_complex(long nStand,
         
         fftwf_free(inX);
         fftwf_free(inY);
-        free(temp2);
+        aligned64_free(temp2);
     }
     fftwf_destroy_plan(p);
     fftwf_free(inP);
@@ -494,7 +494,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     
     // Calculate the windowing function for the PFB
-    pfb = (double*) malloc(sizeof(double) * (1+isReal)*nChan*nTap);
+    pfb = (double*) aligned64_malloc(sizeof(double) * (1+isReal)*nChan*nTap);
     for(int i=0; i<(1+isReal)*nChan*nTap; i++) {
         *(pfb + i) = sinc((i - (1+isReal)*nChan*nTap/2.0 + 0.5)/((1+isReal)*nChan));
         *(pfb + i) *= hamming(2*NPY_PI*i/((1+isReal)*nChan*nTap));
@@ -540,7 +540,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
 #undef LAUNCH_PFB_REAL
 #undef LAUNCH_PFB_COMPLEX
     
-    free(pfb);
+    aligned64_free(pfb);
     
     signalsF = Py_BuildValue("O", PyArray_Return(dataF));
     
@@ -552,7 +552,7 @@ static PyObject *PFBPSD(PyObject *self, PyObject *args, PyObject *kwds) {
     
 fail:
     if( pfb != NULL ) {
-        free(pfb);
+        aligned64_free(pfb);
     }
     Py_XDECREF(dataX);
     Py_XDECREF(dataY);

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -87,7 +87,7 @@ void compute_stokes_real(long nStand,
                 cleanFactor = 1.0;
                 secStart = nSamps * i + 2*nChan*j/Overlap;
                 
-                for(k=0; k<2*nChan*nTap; k++) {
+                for(k=0; k<2*nChan*nTap; k+=2) {
                     if( secStart - 2*nChan*(nTap-1) + k < nSamps*i ) {
                         inX[k] = 0.0;
                         inY[k] = 0.0;
@@ -95,14 +95,24 @@ void compute_stokes_real(long nStand,
                         inX[k] = (float) *(dataX + secStart - 2*nChan*(nTap-1) + k);
                         inY[k] = (float) *(dataY + secStart - 2*nChan*(nTap-1) + k);
                     }
+                    if( secStart - 2*nChan*(nTap-1) + k + 1 < nSamps*i ) {
+                        inX[k+1] = 0.0;
+                        inY[k+1] = 0.0;
+                    } else {
+                        inX[k+1] = (float) *(dataX + secStart - 2*nChan*(nTap-1) + k + 1);
+                        inY[k+1] = (float) *(dataY + secStart - 2*nChan*(nTap-1) + k + 1);
+                    }
                     
-                    if( Clip && ( fabs(inX[k]) >= Clip || fabs(inY[k]) >= Clip ) ) {
+                    if( Clip && (   fabs(inX[k]) >= Clip || fabs(inY[k]) >= Clip \
+                                 || fabs(inX[k+1]) >= Clip || fabs(inY[k+1]) >= Clip) ) {
                         cleanFactor = 0.0;
                     }
                     
                     if( window != NULL ) {
                         inX[k] *= *(window + k);
                         inY[k] *= *(window + k);
+                        inX[k+1] *= *(window + k + 1);
+                        inY[k+1] *= *(window + k + 1);
                     }
                 }
                 

--- a/lsl/correlator/stokes.cpp
+++ b/lsl/correlator/stokes.cpp
@@ -179,7 +179,7 @@ void compute_pfb_real(long nStand,
     pfb = (float*) malloc(sizeof(float) * 2*nChan*PFB_NTAP);
     for(i=0; i<2*nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - 2.0*nChan*PFB_NTAP/2.0 + 0.5)/(2.0*nChan));
-        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(2*nChan*PFB_NTAP));
     }
     
     // Data indexing and access
@@ -428,7 +428,7 @@ void compute_pfb_complex(long nStand,
     pfb = (float*) malloc(sizeof(float) * nChan*PFB_NTAP);
     for(i=0; i<nChan*PFB_NTAP; i++) {
         *(pfb + i) = sinc((i - nChan*PFB_NTAP/2.0 + 0.5)/nChan);
-        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP-1));
+        *(pfb + i) *= hanning(2*NPY_PI*i/(nChan*PFB_NTAP));
     }
     
     // Data indexing and access

--- a/lsl/imaging/gridder.cpp
+++ b/lsl/imaging/gridder.cpp
@@ -17,7 +17,7 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
-#include "../correlator/common.h"
+#include "../correlator/common.hpp"
 
 
 // Maximum number of w-planes to project

--- a/lsl/imaging/gridder.cpp
+++ b/lsl/imaging/gridder.cpp
@@ -146,7 +146,7 @@ void compute_kernel_correction(long nPixSide,
     long i, j;
     OutType temp, temp2;
     OutType *corr_full;
-    corr_full = (OutType*) malloc(nPixSide*GRID_KERNEL_OVERSAMPLE * sizeof(OutType));
+    corr_full = (OutType*) aligned64_malloc(nPixSide*GRID_KERNEL_OVERSAMPLE * sizeof(OutType));
     memset(corr_full, 0, sizeof(OutType)*nPixSide*GRID_KERNEL_OVERSAMPLE);
     
     // Copy the kernel over
@@ -186,7 +186,7 @@ void compute_kernel_correction(long nPixSide,
     }
     
     // Cleanup
-    free(corr_full);
+    aligned64_free(corr_full);
 }
 
 
@@ -217,7 +217,7 @@ void compute_gridding(long nVis,
     
     // Fill in the 1-D gridding kernel
     double *kernel1D;
-    kernel1D = (double *) malloc((GRID_KERNEL_SIZE*GRID_KERNEL_OVERSAMPLE/2+1)*sizeof(double));
+    kernel1D = (double *) aligned64_malloc((GRID_KERNEL_SIZE*GRID_KERNEL_OVERSAMPLE/2+1)*sizeof(double));
     kaiser_bessel_1d_kernel_filler(kernel1D);
     
     long secStart, secStop;
@@ -358,7 +358,7 @@ void compute_gridding(long nVis,
     fftwf_destroy_plan(pR);
     fftwf_free(inP);
     
-    free(kernel1D);
+    aligned64_free(kernel1D);
     
     free(planeStart);
     free(planeStop);

--- a/lsl/misc/wisdom.cpp
+++ b/lsl/misc/wisdom.cpp
@@ -17,7 +17,7 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
-#include "../correlator/common.h"
+#include "../correlator/common.hpp"
 
 
 #define MAXTRANSFORM 262144

--- a/lsl/sim/simfast.cpp
+++ b/lsl/sim/simfast.cpp
@@ -15,23 +15,9 @@
 #include "numpy/npy_math.h"
 
 #include "../common/py3_compat.h"
+#include "../correlator/common.hpp"
 
 #include "protos.h"
-
-
-/*
-  Complex types
-*/
-
-typedef std::complex<float> Complex32;
-typedef std::complex<double> Complex64;
-
-
-/*
-  Macro for 2*pi
-*/
-
-#define TPI (2*NPY_PI*Complex64(0,1))
 
 
 template<typename FluxType, typename OutType>
@@ -75,7 +61,7 @@ void compute_visibility(long nBL,
         #pragma omp parallel default(shared) private(a1, a2, blx, bly, blz, tempHA, tempDec, tempA0, tempA1, tempTheta, tempX, tempVis, x, y, z, u, v, w, i, j, k)
     #endif
     {
-        tempVis = (Complex64 *) malloc(nChan*sizeof(Complex64));
+        tempVis = (Complex64 *) aligned64_malloc(nChan*sizeof(Complex64));
         
         #ifdef _OPENMP
             #pragma omp for schedule(OMP_SCHEDULER)
@@ -155,7 +141,7 @@ void compute_visibility(long nBL,
             }
         }
         
-        free(tempVis);
+        aligned64_free(tempVis);
     }
     
     Py_END_ALLOW_THREADS

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -13,6 +13,7 @@ import time
 import warnings
 import unittest
 import numpy
+from scipy.signal import get_window as scipy_get_window
 
 from lsl.common.paths import DATA_BUILD
 from lsl.common import stations
@@ -46,7 +47,7 @@ def _pfb(data, start, LFFT, ntaps=4):
         if j < 0:
             continue
         sub[i*LFFT:(i+1)*LFFT] = data[j*LFFT:(j+1)*LFFT]
-    sub = sub*_pfb_filter_coeff(LFFT, ntaps)*numpy.hamming(LFFT*ntaps)
+    sub = sub*_pfb_filter_coeff(LFFT, ntaps)*scipy_get_window("hamming", LFFT*ntaps)
     pfb  = numpy.fft.fft(sub[0*LFFT:1*LFFT])
     for i in range(1, ntaps):
         pfb += numpy.fft.fft(sub[i*LFFT:(i+1)*LFFT])

--- a/tests/test_fx.py
+++ b/tests/test_fx.py
@@ -46,7 +46,7 @@ def _pfb(data, start, LFFT, ntaps=4):
         if j < 0:
             continue
         sub[i*LFFT:(i+1)*LFFT] = data[j*LFFT:(j+1)*LFFT]
-    sub = sub*_pfb_filter_coeff(LFFT, ntaps)*numpy.hanning(LFFT*ntaps)
+    sub = sub*_pfb_filter_coeff(LFFT, ntaps)*numpy.hamming(LFFT*ntaps)
     pfb  = numpy.fft.fft(sub[0*LFFT:1*LFFT])
     for i in range(1, ntaps):
         pfb += numpy.fft.fft(sub[i*LFFT:(i+1)*LFFT])


### PR DESCRIPTION
This PR merges the standard and PFB backend functions found in `lsl.correlator` into one.  It also shifts the windowing function in the PFB to Hamming (from Hanning) and provides better documentation as to what the `pfb` option does.