### PR TITLE
Make `lsl.reader.ldp.TBFFile` work with frequency gaps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
  * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' enables a 4-tap Hamming windowed PFB
  * Updated the documentation in lsl.correlator.fx to clarify that 'pfb' overrides the 'window' keyword
  * Added better documentation on the LWA data formats
+ * Fixed a bug in lsl.reader.ldp.TBFFile that caused it to die on files with gaps in the frequency coverage
 
 2.1.7
  * Updated the LWA-SV SSMIF to 2022/11/15

--- a/lsl/reader/ldp.py
+++ b/lsl/reader/ldp.py
@@ -1750,11 +1750,11 @@ class TBFFile(LDPFileBase):
             self.fh.seek(-mlc*tbf.FRAME_SIZE, 1)
             
             # Check for contiguous frequency coverage
-            for i in range(1, nFramesPerObs):
-                if self.mapper[i] - self.mapper[i-1] != tbf.FRAME_CHANNEL_COUNT:
-                    warnings.warn(colorfy("{{%%yellow File appears to contain at least one frequency gap %i channels wide}}" % (self.mapper[i] - self.mapper[i-1])), RuntimeWarning)
-                    break
-                    
+            chan_steps = numpy.diff(self.mapper)
+            if not all(chan_steps == tbf.FRAME_CHANNEL_COUNT):
+                bad_steps = numpy.where(chan_steps != tbf.FRAME_CHANNEL_COUNT)[0]
+                warnings.warn(colorfy("{{%%yellow File appears to contain %i frequency gap(s) of size %s channels}}" % (len(bad_steps), ','.join([str(chan_steps[g]) for g in bad_steps]))), RuntimeWarning)
+                
             # Find the "real" starttime
             while junkFrame.header.frame_count != firstFrameCount:
                 junkFrame = tbf.read_frame(self.fh)

--- a/lsl/reader/ldp.py
+++ b/lsl/reader/ldp.py
@@ -1737,11 +1737,24 @@ class TBFFile(LDPFileBase):
             nFramesPerObs = tbf.get_frames_per_obs(self.fh)
             nchan = tbf.get_channel_count(self.fh)
             firstFrameCount = tbf.get_first_frame_count(self.fh)
-            firstChan = tbf.get_first_channel(self.fh)
             
             # Pre-load the channel mapper
-            self.mapper = [firstChan+i*tbf.FRAME_CHANNEL_COUNT for i in range(nFramesPerObs)]
+            mlc = 0
+            self.mapper = []
+            while len(self.mapper) < nFramesPerObs:
+                junkFrame = tbf.read_frame(self.fh)
+                mlc += 1
+                if junkFrame.header.first_chan not in self.mapper:
+                    self.mapper.append(junkFrame.header.first_chan)
+            self.mapper.sort()
+            self.fh.seek(-mlc*tbf.FRAME_SIZE, 1)
             
+            # Check for contiguous frequency coverage
+            for i in range(1, nFramesPerObs):
+                if self.mapper[i] - self.mapper[i-1] != tbf.FRAME_CHANNEL_COUNT:
+                    warnings.warn(colorfy("{{%%yellow File appears to contain at least one frequency gap %i channels wide}}" % (self.mapper[i] - self.mapper[i-1])), RuntimeWarning)
+                    break
+                    
             # Find the "real" starttime
             while junkFrame.header.frame_count != firstFrameCount:
                 junkFrame = tbf.read_frame(self.fh)


### PR DESCRIPTION
This PR addresses #48 where `TBFFile.read()` dies on files that do not have contiguous frequency coverage across the two tunings.