### PR TITLE
HTTPError on data_access.py

### DIFF
--- a/lsl/common/data_access.py
+++ b/lsl/common/data_access.py
@@ -12,6 +12,7 @@ try:
     from urllib2 import urlopen
 except ImportError:
     from urllib.request import urlopen
+from urllib.error import HTTPError
 
 from lsl.common.paths import DATA as DATA_PATH
 from lsl.common.progress import DownloadBar
@@ -114,7 +115,7 @@ class _DataAccess(object):
                 mtime = calendar.timegm(mtime.timetuple())
         except socket.timeout:
             pass
-        except:
+        except HTTPError:
             pass
             
         return mtime

--- a/lsl/common/data_access.py
+++ b/lsl/common/data_access.py
@@ -114,6 +114,8 @@ class _DataAccess(object):
                 mtime = calendar.timegm(mtime.timetuple())
         except socket.timeout:
             pass
+        except:
+            pass
             
         return mtime
         


### PR DESCRIPTION
HTTP 404 errors on import of stations from lsl.common (ex. with smartCopyHelper.py). Stations is called for station specific details so this could possibly affect other code in lsl too. 