### PR TITLE
Drop `numpy.matrix` in favor of `numpy.array` and `numpy.dot`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
  * Changed lsl.common.metabundle into a general module that can work with metadata from any station
  * Added a DRX8 reader for future data format support
  * Updated gatherDebugging.py to make it more useful
+ * Dropped the 'indicies' keyword from lsl.correlator.uvutils
 
 2.2.0
  * Add a keyword to lsl.imaging.selfcal functions that will return whether or not a call converged

--- a/lsl/correlator/fx.py
+++ b/lsl/correlator/fx.py
@@ -253,22 +253,24 @@ def FXMaster(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
     
     # Get the location of the phase center in radians and create a 
     # pointing vector
-    if phase_center == 'z':
-        azPC = 0.0
-        altPC = np.pi/2.0
-    else:
-        if isinstance(phase_center, AltAz):
-            azPC = phase_center.az.rad
-            altPC = phase_center.alt.rad
-        elif isinstance(phase_center, SkyCoord) and isinstance(phase_center.frame, AltAz):
-            azPC = phase_center.az.rad
-            altPC = phase_center.alt.rad
-        elif isinstance(phase_center, ephem.Body):
-            azPC = phase_center.az * 1.0
-            altPC = phase_center.alt * 1.0
+    if isinstance(phase_center, str):
+        if phase_center == 'z':
+            azPC = 0.0
+            altPC = np.pi/2.0
         else:
-            azPC = phase_center[0]*np.pi/180.0
-            altPC = phase_center[1]*np.pi/180.0
+            raise ValueError(f"Unknown phase_center '{phase_center}'")
+    elif isinstance(phase_center, AltAz):
+        azPC = phase_center.az.rad
+        altPC = phase_center.alt.rad
+    elif isinstance(phase_center, SkyCoord) and isinstance(phase_center.frame, AltAz):
+        azPC = phase_center.az.rad
+        altPC = phase_center.alt.rad
+    elif isinstance(phase_center, ephem.Body):
+        azPC = phase_center.az * 1.0
+        altPC = phase_center.alt * 1.0
+    else:
+        azPC = phase_center[0]*np.pi/180.0
+        altPC = phase_center[1]*np.pi/180.0
             
     source = np.array([np.cos(altPC)*np.sin(azPC), 
                        np.cos(altPC)*np.cos(azPC), 
@@ -407,22 +409,24 @@ def FXStokes(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
     
     # Get the location of the phase center in radians and create a 
     # pointing vector
-    if phase_center == 'z':
-        azPC = 0.0
-        altPC = np.pi/2.0
-    else:
-        if isinstance(phase_center, AltAz):
-            azPC = phase_center.az.rad
-            altPC = phase_center.alt.rad
-        elif isinstance(phase_center, SkyCoord) and isinstance(phase_center.frame, AltAz):
-            azPC = phase_center.az.rad
-            altPC = phase_center.alt.rad
-        elif isinstance(phase_center, ephem.Body):
-            azPC = phase_center.az * 1.0
-            altPC = phase_center.alt * 1.0
+    if isinstance(phase_center, str):
+        if phase_center == 'z':
+            azPC = 0.0
+            altPC = np.pi/2.0
         else:
-            azPC = phase_center[0]*np.pi/180.0
-            altPC = phase_center[1]*np.pi/180.0
+            raise ValueError(f"Unknown phase_center '{phase_center}'")
+    elif isinstance(phase_center, AltAz):
+        azPC = phase_center.az.rad
+        altPC = phase_center.alt.rad
+    elif isinstance(phase_center, SkyCoord) and isinstance(phase_center.frame, AltAz):
+        azPC = phase_center.az.rad
+        altPC = phase_center.alt.rad
+    elif isinstance(phase_center, ephem.Body):
+        azPC = phase_center.az * 1.0
+        altPC = phase_center.alt * 1.0
+    else:
+        azPC = phase_center[0]*np.pi/180.0
+        altPC = phase_center[1]*np.pi/180.0
     source = np.array([np.cos(altPC)*np.sin(azPC), 
                        np.cos(altPC)*np.cos(azPC), 
                        np.sin(altPC)])

--- a/lsl/correlator/fx.py
+++ b/lsl/correlator/fx.py
@@ -227,7 +227,7 @@ def FXMaster(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
     signalsIndex2 = [i for (i, a) in enumerate(antennas) if a.pol == pol2]
     
     nStands = len(antennas1)
-    baselines = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=include_auto, indicies=True)
+    baselines = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=include_auto)
     
     # Figure out if we are working with complex (I/Q) data or only real.  This
     # will determine how the FFTs are done since the real data mirrors the pos-
@@ -323,25 +323,22 @@ def FXMaster(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
         # Remove auto-correlations from the output of the X engine if we don't 
         # need them.  To do this we need to first build the full list of baselines
         # (including auto-correlations) and then prune that.
-        baselinesFull = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=True, indicies=True)
-        fom = np.array([a1-a2 for (a1,a2) in baselinesFull])
-        nonAuto = np.where( fom != 0 )[0]
+        baselinesFull = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=True)
+        fom = np.array([a1.stand != a2.stand for (a1,a2) in baselinesFull])
+        nonAuto = np.where(fom)[0]
         output = output[nonAuto,:]
         
     # Apply cable gain corrections (if needed)
     if gain_correct:
         for bl in range(output.shape[0]):
-            cableGain1 = antennas1[baselines[bl][0]].cable.gain(freq)
-            cableGain2 = antennas2[baselines[bl][1]].cable.gain(freq)
+            cableGain1 = baselines[bl][0].cable.gain(freq)
+            cableGain2 = baselines[bl][1].cable.gain(freq)
             
             output[bl,:] /= np.sqrt(cableGain1*cableGain2)
             
     # Create antenna baseline list (if needed)
     if return_baselines:
-        antennaBaselines = []
-        for bl in range(output.shape[0]):
-            antennaBaselines.append( (antennas1[baselines[bl][0]], antennas2[baselines[bl][1]]) )
-        returnValues = (antennaBaselines, freq, output)
+        returnValues = (baselines, freq, output)
     else:
         returnValues = (freq, output)
 
@@ -384,7 +381,7 @@ def FXStokes(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
     signalsIndex2 = [i for (i, a) in enumerate(antennas) if a.pol == pol2]
     
     nStands = len(antennas1)
-    baselines = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=include_auto, indicies=True)
+    baselines = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=include_auto)
     
     # Figure out if we are working with complex (I/Q) data or only real.  This
     # will determine how the FFTs are done since the real data mirrors the pos-
@@ -472,25 +469,22 @@ def FXStokes(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
         # Remove auto-correlations from the output of the X engine if we don't 
         # need them.  To do this we need to first build the full list of baselines
         # (including auto-correlations) and then prune that.
-        baselinesFull = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=True, indicies=True)
-        fom = np.array([a1-a2 for (a1,a2) in baselinesFull])
-        nonAuto = np.where( fom != 0 )[0]
+        baselinesFull = uvutils.get_baselines(antennas1, antennas2=antennas2, include_auto=True)
+        fom = np.array([a1.stand != a2.stand for (a1,a2) in baselinesFull])
+        nonAuto = np.where(fom)[0]
         output = output[:,nonAuto,:]
         
     # Apply cable gain corrections (if needed)
     if gain_correct:
         for bl in range(output.shape[0]):
-            cableGain1 = antennas1[baselines[bl][0]].cable.gain(freq)
-            cableGain2 = antennas2[baselines[bl][1]].cable.gain(freq)
+            cableGain1 = baselines[bl][0].cable.gain(freq)
+            cableGain2 = baselines[bl][1].cable.gain(freq)
             
             output[:,bl,:] /= np.sqrt(cableGain1*cableGain2)
             
     # Create antenna baseline list (if needed)
     if return_baselines:
-        antennaBaselines = []
-        for bl in range(output.shape[1]):
-            antennaBaselines.append( (antennas1[baselines[bl][0]], antennas2[baselines[bl][1]]) )
-        returnValues = (antennaBaselines, freq, output)
+        returnValues = (baselines, freq, output)
     else:
         returnValues = (freq, output)
 

--- a/lsl/correlator/fx.py
+++ b/lsl/correlator/fx.py
@@ -258,7 +258,7 @@ def FXMaster(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
             azPC = 0.0
             altPC = np.pi/2.0
         else:
-            raise ValueError(f"Unknown phase_center '{phase_center}'")
+            raise ValueError(f"Unrecognized source: {phase_center}")
     elif isinstance(phase_center, AltAz):
         azPC = phase_center.az.rad
         altPC = phase_center.alt.rad
@@ -414,7 +414,7 @@ def FXStokes(signals, antennas, LFFT=64, overlap=1, include_auto=False, verbose=
             azPC = 0.0
             altPC = np.pi/2.0
         else:
-            raise ValueError(f"Unknown phase_center '{phase_center}'")
+            raise ValueError(f"Unrecognized source: {phase_center}")
     elif isinstance(phase_center, AltAz):
         azPC = phase_center.az.rad
         altPC = phase_center.alt.rad

--- a/lsl/correlator/uvutils.py
+++ b/lsl/correlator/uvutils.py
@@ -157,10 +157,10 @@ def compute_uvw(antennas_or_baselines, HA=0.0, dec=34.070, freq=49.0e6, site=lwa
     """
     
     # Try this so that freq can be either a scalar, a list, or an array
-    try: 
-        freq.size
-        assert(freq.shape != ())
-    except (AttributeError, AssertionError):
+    if isinstance(freq, np.ndarray):
+        if freq.shape == ():
+            raise RuntimeError("No frequencies provided")
+    else:
         freq = np.array(freq, ndmin=1)
         
     if isinstance(antennas_or_baselines[0], Antenna):

--- a/lsl/correlator/uvutils.py
+++ b/lsl/correlator/uvutils.py
@@ -18,6 +18,9 @@ coverage and time delays.  The functions in the module:
     Added support for ephem.Angle, astropy.coordinates.Angle, and 
     astropy.coordinates.EarthLocation instances in the compute_uvw() and 
     compute_uv_track() functions.
+    
+.. versionchanged:: 3.0.0
+    Dropped support for the 'indicies' keyword.
 """
 
 import ephem
@@ -44,43 +47,43 @@ __all__ = ['get_baselines', 'baseline_to_antennas', 'antennas_to_baseline',
 speedOfLight = speedOfLight.to('m/s').value
 
 
-def get_baselines(antennas, antennas2=None, include_auto=False, indicies=False):
+def get_baselines(antennas, antennas2=None, include_auto=False):
     """
     Generate a list of two-element tuples that describe which antennae
     compose each of the output uvw triplets from compute_uvw/compute_uv_track.
-    If the indicies keyword is set to True, the two-element tuples 
-    contain the indicies of the stands array used, rather than the actual
-    stand numbers.
+    
+    .. versionchanged:: 3.0.0
+        Dropped the 'indicies' keyword.
     """
-
+    
     if include_auto:
         offset = 0
     else:
         offset = 1
-
+        
     out = []
     N = len(antennas)
     
     # If we don't have an antennas2 array, use antennas again
     if antennas2 is None:
         antennas2 = antennas
-    
-    for i in range(0, N-offset):
+        
+    for i in range(0, N):
         for j in range(i+offset, N):
-            if indicies:
-                out.append( (i, j) )
-            else:
-                out.append( (antennas[i], antennas2[j]) )
-
+            out.append( (antennas[i], antennas2[j]) )
+            
     return out
     
 
-def baseline_to_antennas(baseline, antennas, antennas2=None, baseline_list=None, include_auto=False, indicies=False):
+def baseline_to_antennas(baseline, antennas, antennas2=None, baseline_list=None, include_auto=False):
     """
     Given a baseline number, a list of stands, and options of how the base-
     line listed was generated, convert the baseline number to antenna numbers.
     Alternatively, use a list of baselines instead of generating a new list.  
     This utility is useful for figuring out what antennae comprise a baseline.
+    
+    .. versionchanged:: 3.0.0
+        Dropped the 'indicies' keyword.
     """
     
     # If we don't have an antennas2 array, use antennas again
@@ -89,37 +92,37 @@ def baseline_to_antennas(baseline, antennas, antennas2=None, baseline_list=None,
 
     # Build up the list of baselines using the options provided
     if baseline_list is None:
-        baseline_list = get_baselines(antennas, antennas2=antennas2, include_auto=include_auto, indicies=indicies)
+        baseline_list = get_baselines(antennas, antennas2=antennas2, include_auto=include_auto)
     
     # Select the correct one and return based on the value of indicies
-    i,j = baseline_list[baseline]
-    return i,j
+    return baseline_list[baseline]
 
 
-def antennas_to_baseline(ant1, ant2, antennas, antennas2=None, baseline_list=None, include_auto=False, indicies=False):
+def antennas_to_baseline(ant1, ant2, antennas, antennas2=None, baseline_list=None, include_auto=False):
     """
     Given two antenna numbers, a list of stands, and options to how the base-
     line listed was generated, convert the antenna pair to  a baseline number. 
     This utility is useful for picking out a particular pair from a list of
     baselines.
+    
+    .. versionchanged:: 3.0.0
+        Dropped the 'indicies' keyword.
     """
     
     # If we don't have an antennas2 array, use antennas again
     if antennas2 is None:
         antennas2 = antennas
-
+        
     # Build up the list of baselines using the options provided
     if baseline_list is None:
-        baseline_list = get_baselines(antennas, antennas2=antennas2, include_auto=include_auto, indicies=indicies)
-    
+        baseline_list = get_baselines(antennas, antennas2=antennas2, include_auto=include_auto)
+        
     # Loop over the baselines until we find one that matches.  If we don't find 
     # one, return -1
-    i = 0
-    for baseline in baseline_list:
+    for i,baseline in enumerate(baseline_list):
         if ant1 in baseline and ant2 in baseline:
             return i
-        i = i + 1
-        
+            
     return -1
 
 
@@ -161,7 +164,7 @@ def compute_uvw(antennas_or_baselines, HA=0.0, dec=34.070, freq=49.0e6, site=lwa
         freq = np.array(freq, ndmin=1)
         
     if isinstance(antennas_or_baselines[0], Antenna):
-        baselines = get_baselines(antennas_or_baselines, include_auto=include_auto, indicies=False)
+        baselines = get_baselines(antennas_or_baselines, include_auto=include_auto)
     elif isinstance(antennas_or_baselines[0], (tuple, list)):
         if isinstance(antennas_or_baselines[0][0], Antenna) and len(antennas_or_baselines[0]) == 2:
             baselines = antennas_or_baselines
@@ -248,7 +251,7 @@ def compute_uv_track(antennas_or_baselines, dec=34.070, freq=49.0e6, site=lwa1):
     """
     
     if isinstance(antennas_or_baselines[0], Antenna):
-        baselines = get_baselines(antennas_or_baselines, include_auto=False, indicies=False)
+        baselines = get_baselines(antennas_or_baselines, include_auto=False)
     elif isinstance(antennas_or_baselines[0], (tuple, list)):
         if isinstance(antennas_or_baselines[0][0], Antenna) and len(antennas_or_baselines[0]) == 2:
             baselines = antennas_or_baselines

--- a/lsl/sim/vis.py
+++ b/lsl/sim/vis.py
@@ -1047,7 +1047,7 @@ def __build_sim_data(aa, srcs, pols=['xx', 'yy', 'xy', 'yx'], jd=None, chan=None
     # Build the simulated data.  If no baseline list is provided, build all 
     # baselines available
     if baselines is None:
-        baselines = uvutils.get_baselines(np.zeros(len(aa.ants)), indicies=True)
+        baselines = uvutils.get_baselines(np.arange(len(aa.ants)))
         
     # Define output data structure
     freq = aa.get_afreqs()*1e9

--- a/scripts/correlateTBF.py
+++ b/scripts/correlateTBF.py
@@ -127,11 +127,8 @@ def process_chunk(idf, site, good, filename, freq_decim=1, int_time=5.0, pols=['
                 a2, d2, v2 = antennasY, dataY, validY
                 
             ## Get the baselines
-            baselines = uvutils.get_baselines(a1, antennas2=a2, include_auto=True, indicies=True)
-            blList = []
-            for bl in range(len(baselines)):
-                blList.append( (a1[baselines[bl][0]], a2[baselines[bl][1]]) )
-                
+            baselines = uvutils.get_baselines(a1, antennas2=a2, include_auto=True)
+            
             ## Run the cross multiply and accumulate
             vis = XEngine2(d1, d2, v1, v2)
             
@@ -150,7 +147,7 @@ def process_chunk(idf, site, good, filename, freq_decim=1, int_time=5.0, pols=['
                 fits.set_geometry(site, [a for a in mapper if a.pol == pol1])
                 
             # Convert the setTime to a MJD and save the visibilities to the FITS IDI file
-            fits.add_data_set(setTime, readT, blList, vis[:,toUse], pol=pol)
+            fits.add_data_set(setTime, readT, baselines, vis[:,toUse], pol=pol)
         print(f"->  Cummulative Wall Time: {time.time()-wallTime:.3f} s ({(time.time()-wallTime)/(s+1):.3f} s per integration)")
         
     # Cleanup after everything is done

--- a/tests/test_fitsidi.py
+++ b/tests/test_fitsidi.py
@@ -51,7 +51,7 @@ class fitsidi_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
 
@@ -522,7 +522,7 @@ class aipsidi_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
 

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -131,7 +131,7 @@ class imaging_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
         

--- a/tests/test_measurementset.py
+++ b/tests/test_measurementset.py
@@ -55,7 +55,7 @@ class measurementset_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
         

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -70,4 +70,3 @@ class scripts_test_suite(unittest.TestSuite):
 
 if __name__ == '__main__':
     unittest.main()
-    

--- a/tests/test_simvis.py
+++ b/tests/test_simvis.py
@@ -4,6 +4,7 @@ Unit test for the lsl.sim.vis module.
 
 import os
 import unittest
+import ephem
 import numpy as np
 
 import aipy
@@ -206,6 +207,31 @@ class simvis_tests(unittest.TestCase):
         self.assertTrue('YX' in out.pols)
         self.assertTrue('YY' in out.pols)
         
+    def test_build_data_phase_center(self):
+        """Test building simulated visibility data with different phase center types."""
+        
+        # Setup
+        lwa1 = lwa_common.lwa1
+        antennas = lwa1.antennas[0:20]
+        freqs = np.arange(30e6, 50e6, 1e6)
+        aa = vis.build_sim_array(lwa1, antennas, freqs)
+        
+        # Build the data dictionary - a few times
+        with self.subTest(type='str'):
+            out = vis.build_sim_data(aa, vis.SOURCES, phase_center='z')
+            self.assertRaises(ValueError, vis.build_sim_data, aa, vis.SOURCES, phase_center='notgoingtowork')
+            
+        with self.subTest(type='ephem.Body'):
+            bdy = ephem.FixedBody()
+            bdy._ra = '1:02:03'
+            bdy._dec = '+89:00:00'
+            bdy._epoch = ephem.J2000
+            
+            out = vis.build_sim_data(aa, vis.SOURCES, phase_center=bdy)
+            self.assertAlmostEqual(out.phase_center._ra, bdy._ra, 6)
+            self.assertAlmostEqual(out.phase_center._dec, bdy._dec, 6)
+            self.assertAlmostEqual(out.phase_center._epoch, bdy._epoch, 6)
+            
     def test_scale_data(self):
         """Test that we can scale a data dictionary without error"""
         

--- a/tests/test_simvis.py
+++ b/tests/test_simvis.py
@@ -9,6 +9,8 @@ import numpy as np
 
 import aipy
 
+from astropy.coordinates import SkyCoord
+
 from lsl.sim import vis
 from lsl.imaging.data import VisibilityData
 from lsl.common import stations as lwa_common
@@ -231,6 +233,13 @@ class simvis_tests(unittest.TestCase):
             self.assertAlmostEqual(out.phase_center._ra, bdy._ra, 6)
             self.assertAlmostEqual(out.phase_center._dec, bdy._dec, 6)
             self.assertAlmostEqual(out.phase_center._epoch, bdy._epoch, 6)
+            
+        with self.subTest(type='astropy.coordinates.SkyCoord'):
+            sc = SkyCoord('1h02m03s', '+89d00m00s', frame='fk5', equinox='J2000')
+            
+            out = vis.build_sim_data(aa, vis.SOURCES, phase_center=sc)
+            self.assertAlmostEqual(out.phase_center._ra, sc.ra.rad, 6)
+            self.assertAlmostEqual(out.phase_center._dec, sc.dec.rad, 6)
             
     def test_scale_data(self):
         """Test that we can scale a data dictionary without error"""

--- a/tests/test_uvfits.py
+++ b/tests/test_uvfits.py
@@ -48,7 +48,7 @@ class uvfits_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
         

--- a/tests/test_uvutils.py
+++ b/tests/test_uvutils.py
@@ -64,7 +64,7 @@ class uvutils_tests(unittest.TestCase):
         ind = uvutils.antennas_to_baseline(100, 102, standList, baseline_list=bl)
         self.assertEqual(ind, 1)
         
-        ind = uvutils.antennas_to_baseline(0, 3, standList, include_auto=False)
+        ind = uvutils.antennas_to_baseline(100, 103, standList, include_auto=False)
         self.assertEqual(ind, 2)
         
     def run_compute_uvw_test(self, antennas, freq, HA=0.0, dec=34.0):

--- a/tests/test_uvutils.py
+++ b/tests/test_uvutils.py
@@ -64,8 +64,8 @@ class uvutils_tests(unittest.TestCase):
         ind = uvutils.antennas_to_baseline(100, 102, standList, baseline_list=bl)
         self.assertEqual(ind, 1)
         
-        ind = uvutils.antennas_to_baseline(100, 103, standList, include_auto=False)
-        self.assertEqual(ind, 2)
+        ind = uvutils.antennas_to_baseline(100, 103, standList, include_auto=True)
+        self.assertEqual(ind, 3)
         
     def run_compute_uvw_test(self, antennas, freq, HA=0.0, dec=34.0):
         out = uvutils.compute_uvw(antennas, HA=HA, dec=dec, freq=freq)

--- a/tests/test_uvutils.py
+++ b/tests/test_uvutils.py
@@ -33,37 +33,17 @@ class uvutils_tests(unittest.TestCase):
 
         standList = np.array([100, 101, 102, 103])
 
-        bl = uvutils.get_baselines(standList, include_auto=False, indicies=False)
+        bl = uvutils.get_baselines(standList, include_auto=False)
         self.assertEqual(len(bl), 6)
-        bl = uvutils.get_baselines(standList, include_auto=True, indicies=False)
+        bl = uvutils.get_baselines(standList, include_auto=True)
         self.assertEqual(len(bl), 10)
-
-    def test_baseline_ind(self):
-        """Test that the baselines generated with indicies do return indicies and vice
-        versa."""
-
-        standList = np.array([100, 101, 102, 103])
-
-        bl = uvutils.get_baselines(standList, include_auto=False, indicies=False)
-        bl = np.array(bl)
-        self.assertTrue(bl.min() == 100)
-        bl = uvutils.get_baselines(standList, include_auto=True, indicies=False)
-        bl = np.array(bl)
-        self.assertTrue(bl.min() == 100)
-
-        bl = uvutils.get_baselines(standList, include_auto=False, indicies=True)
-        bl = np.array(bl)
-        self.assertTrue(bl.max() < 100)
-        bl = uvutils.get_baselines(standList, include_auto=True, indicies=True)
-        bl = np.array(bl)
-        self.assertTrue(bl.max() < 100)
         
     def test_antenna_lookup(self):
         """Test baseline number to antenna lookup function."""
         
         standList = np.array([100, 101, 102, 103])
 
-        bl = uvutils.get_baselines(standList, include_auto=False, indicies=False)
+        bl = uvutils.get_baselines(standList, include_auto=False)
         ind = uvutils.baseline_to_antennas(0, standList)
         self.assertEqual(ind[0], 100)
         self.assertEqual(ind[1], 101)
@@ -76,15 +56,15 @@ class uvutils_tests(unittest.TestCase):
         """Test antennas to baseline lookup function."""
         
         standList = np.array([100, 101, 102, 103])
-        bl = uvutils.get_baselines(standList, include_auto=False, indicies=False)
+        bl = uvutils.get_baselines(standList, include_auto=False)
         
-        ind = uvutils.antennas_to_baseline(100, 101, standList, include_auto=False, indicies=False)
+        ind = uvutils.antennas_to_baseline(100, 101, standList, include_auto=False)
         self.assertEqual(ind, 0)
         
         ind = uvutils.antennas_to_baseline(100, 102, standList, baseline_list=bl)
         self.assertEqual(ind, 1)
         
-        ind = uvutils.antennas_to_baseline(0, 3, standList, include_auto=False, indicies=True)
+        ind = uvutils.antennas_to_baseline(0, 3, standList, include_auto=False)
         self.assertEqual(ind, 2)
         
     def run_compute_uvw_test(self, antennas, freq, HA=0.0, dec=34.0):
@@ -141,13 +121,9 @@ class uvutils_tests(unittest.TestCase):
         np.testing.assert_allclose(out0, out2)
         
         # Pass in a list of baselines
-        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False, indicies=False)
+        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False)
         out3 = uvutils.compute_uvw(bl, freq=freq)
         self.assertEqual(len(out3), len(bl))
-        
-        # Pass in a list of baseline indicies
-        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False, indicies=True)
-        self.assertRaises(TypeError, uvutils.compute_uvw, bl, {'freq': freq})
         
         # Angle support
         freq = [45e6, 60e6]
@@ -177,13 +153,9 @@ class uvutils_tests(unittest.TestCase):
         self.assertEqual(out.shape, (435,2,512))
         
         # Pass in a list of baselines
-        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False, indicies=False)
+        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False)
         out0 = uvutils.compute_uv_track(bl)
         self.assertEqual(len(out0), len(bl))
-        
-        # Pass in a list of baseline indicies
-        bl = uvutils.get_baselines(antennas[0:30:2], include_auto=False, indicies=True)
-        self.assertRaises(TypeError, uvutils.compute_uv_track, bl)
         
         # Angle support
         dec = 34.0

--- a/tests/test_virtual.py
+++ b/tests/test_virtual.py
@@ -45,7 +45,7 @@ class virtual_tests(unittest.TestCase):
         antennas = site.antennas[0:40:2]
         
         # Set baselines and data
-        blList = uvutils.get_baselines(antennas, include_auto=True, indicies=False)
+        blList = uvutils.get_baselines(antennas, include_auto=True)
         visData = np.random.rand(len(blList), len(freq))
         visData = visData.astype(np.complex64)
 


### PR DESCRIPTION
This PR cleans up `lsl.correlator.uvutils` to remove calls to `numpy.matrix`.  It also cleans up the various functions in this module to remove the `indicies` keyword.